### PR TITLE
Use yum repo instead of a specific Jenkins version

### DIFF
--- a/jenkins/jenkins2-ha.json
+++ b/jenkins/jenkins2-ha.json
@@ -376,15 +376,19 @@
               "d_mountpoint_mount": {
                 "command": {"Fn::Join": ["", ["mount -t nfs4 -o vers=4.1 \"$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).", {"Ref": "MasterStorage"}, ".efs.", {"Ref": "AWS::Region"}, ".amazonaws.com:/\" /var/lib/jenkins"]]},
                 "test": "if mount | grep -q /var/lib/jenkins; then exit 1; else exit 0; fi"
+              },
+              "e_jenkins_repo": {
+                "command" : "wget -O /etc/yum.repos.d/jenkins.repo http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo"
+              },
+              "f_jenkins_key": {
+                "command" : "rpm --import https://jenkins-ci.org/redhat/jenkins-ci.org.key"
               }
             }
           },
           "install": {
             "packages": {
-              "rpm": {
-                "jenkins": "http://pkg.jenkins-ci.org/redhat-stable/jenkins-2.7.4-1.1.noarch.rpm"
-              },
               "yum": {
+                "jenkins": [],
                 "git": [],
                 "awslogs": []
               }

--- a/jenkins/jenkins2-ha.json
+++ b/jenkins/jenkins2-ha.json
@@ -55,6 +55,12 @@
       "Type": "Number",
       "AllowedValues": [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653],
       "Default": 14
+    },
+    "JenkinsVersion": {
+      "Description": "Jenkins version number",
+      "Type": "String",
+      "AllowedPattern": "[0-9]+\\.[0-9]+\\.[0-9]+",
+      "Default": "2.7.4"
     }
   },
   "Mappings": {
@@ -376,19 +382,15 @@
               "d_mountpoint_mount": {
                 "command": {"Fn::Join": ["", ["mount -t nfs4 -o vers=4.1 \"$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).", {"Ref": "MasterStorage"}, ".efs.", {"Ref": "AWS::Region"}, ".amazonaws.com:/\" /var/lib/jenkins"]]},
                 "test": "if mount | grep -q /var/lib/jenkins; then exit 1; else exit 0; fi"
-              },
-              "e_jenkins_repo": {
-                "command" : "wget -O /etc/yum.repos.d/jenkins.repo http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo"
-              },
-              "f_jenkins_key": {
-                "command" : "rpm --import https://jenkins-ci.org/redhat/jenkins-ci.org.key"
               }
             }
           },
           "install": {
             "packages": {
+              "rpm": {
+                "jenkins": {"Fn::Join": ["", ["http://pkg.jenkins-ci.org/redhat-stable/jenkins-", {"Ref": "JenkinsVersion"}, "-1.1.noarch.rpm"]]}
+              },
               "yum": {
-                "jenkins": [],
                 "git": [],
                 "awslogs": []
               }


### PR DESCRIPTION
Changed to use official LTS yum repository for Jenkins installation instead of specific Jenkins version.

Ref: https://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins+on+Red+Hat+distributions#InstallingJenkinsonRedHatdistributions-Installationofastableversion