### PR TITLE
Clarify certificates in wordpress steps

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -21,8 +21,8 @@ This template combines the following services:
 
 ## Installation Guide
 1. This templates depends on our [`vpc-*azs.yaml`](../vpc/) template. WordPress will use 2 AZs only. <a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=vpc-2azs&templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates/vpc/vpc-2azs.yaml">Launch Stack</a>
-1. Create an ACM certificate for your domain name within the region you want to launch your stack in. Copy the ARN of the certificate.
-1. Create another ACM certificate for your domain in region `us-east-1`. Copy the ARN of the certificate.
+1. Create an ACM certificate for your domain name within the region you want to launch your stack in. Copy the ARN of the certificate. This is for the ELB.
+1. Create another ACM certificate for your domain in region `us-east-1`. Copy the ARN of the certificate. This is for CloudFront (note: [CloudFront only supports ACM certificates in us-east-1](https://docs.aws.amazon.com/acm/latest/userguide/acm-services.html))
 1. <a href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=wordpress-ha&templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates/wordpress/wordpress-ha.yaml">Launch Stack</a>
 1. Click **Next** to proceed with the next step of the wizard.
 1. Specify a name and all parameters for the stack.


### PR DESCRIPTION
This change makes each certificate clearer. I wasted half an hour because of a mis-named certificate in the wrong region. This phrasing should prevent such mistakes for future users.

 - clarify which certificate is for the ELB.
 - clarify which certificate is for CloudFront (and why)