### PR TITLE
Enable http2 for cloudfront static sites.

### DIFF
--- a/static-website/static-website.yaml
+++ b/static-website/static-website.yaml
@@ -102,6 +102,7 @@ Resources:
           TargetOriginId: s3origin
           ViewerProtocolPolicy: 'redirect-to-https'
         Enabled: true
+        HttpVersion: http2
         PriceClass: 'PriceClass_All'
         ViewerCertificate:
           AcmCertificateArn: !If [HasCreateAcmCertificate, !Ref Certificate, !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref 'AWS::NoValue']] 
@@ -157,6 +158,7 @@ Resources:
           TargetOriginId: s3origin
           ViewerProtocolPolicy: 'redirect-to-https'
         Enabled: true
+        HttpVersion: http2
         PriceClass: 'PriceClass_All'
         ViewerCertificate:
           AcmCertificateArn: !If [HasCreateAcmCertificate, !Ref Certificate, !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref 'AWS::NoValue']] 


### PR DESCRIPTION
Before this change, static websites deployed using this template would not support http2. Here is a handy tool to test whether a given site is supporting http2: https://tools.keycdn.com/http2-test

In september 2016 CloudFront started supporting HTTP2 with graceful fallback to older versions. 
https://aws.amazon.com/blogs/aws/new-http2-support-for-cloudfront/

The HttpVersion parameter in the CloudFormation CloudFront configuration object is optional, and when not specified it defaults to the older value.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html

This change specifies HttpVersion as http2 for the CloudFront distributions, which will give better performance and doesn't cost any extra.

Thanks for publishing these templates!