### PR TITLE
added parameter for ALB deregistration delay

### DIFF
--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -16,6 +16,7 @@ Metadata:
       - LoadBalancerHostPattern
       - LoadBalancerPath
       - LoadBalancerHttps
+      - LoadBalancerDeregistrationDelay
     - Label:
         default: 'Task Parameters'
       Parameters:
@@ -57,6 +58,13 @@ Parameters:
     AllowedValues:
     - true
     - false
+  LoadBalancerDeregistrationDelay:
+    Description: 'The amount time (in seconds) to wait before changing the state of a deregistering target from draining to unused.'
+    Type: Number
+    Default: 300
+    ConstraintDescription: 'Must be in the range [0-3600]'
+    MinValue: 0
+    MaxValue: 3600
   Image:
     Description: 'The image to use for a container, which is passed directly to the Docker daemon. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
@@ -120,6 +128,9 @@ Resources:
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentClusterStack}-VPC'
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: !Ref LoadBalancerDeregistrationDelay
   LoadBalancerHttpListenerRule:
     Type: 'AWS::ElasticLoadBalancingV2::ListenerRule'
     Properties:

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -16,6 +16,7 @@ Metadata:
       Parameters:
       - LoadBalancerScheme
       - LoadBalancerCertificateArn
+      - LoadBalancerDeregistrationDelay
     - Label:
         default: 'Task Parameters'
       Parameters:
@@ -49,6 +50,13 @@ Parameters:
     Description: 'Optional Amazon Resource Name (ARN) of the certificate to associate with the load balancer.'
     Type: String
     Default: ''
+  LoadBalancerDeregistrationDelay:
+    Description: 'The amount time (in seconds) to wait before changing the state of a deregistering target from draining to unused.'
+    Type: Number
+    Default: 300
+    ConstraintDescription: 'Must be in the range [0-3600]'
+    MinValue: 0
+    MaxValue: 3600
   Image:
     Description: 'The image to use for a container, which is passed directly to the Docker daemon. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
@@ -168,6 +176,9 @@ Resources:
       UnhealthyThresholdCount: 4
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: !Ref LoadBalancerDeregistrationDelay
   HTTPCodeELB5XXTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'


### PR DESCRIPTION
Added parameters to be able to configure the Deregistration Delay for the Target Group. Decreases time needed for deployment of new images for a service.