### PR TITLE
static website template: support both dot region and dash region s3 website endpoints

### DIFF
--- a/static-website/static-website.yaml
+++ b/static-website/static-website.yaml
@@ -84,7 +84,7 @@ Resources:
         - !Ref DomainName
         Comment: !Ref DomainName
         Origins:
-        - DomainName: !Sub '${S3Bucket}.s3-website-${AWS::Region}.amazonaws.com'
+        - DomainName: !Select [ 2, !Split [ /, !GetAtt S3Bucket.WebsiteURL ] ]
           Id: s3origin
           CustomOriginConfig:
             OriginProtocolPolicy: 'http-only'
@@ -140,7 +140,7 @@ Resources:
         - !Ref RedirectDomainName
         Comment: !Ref RedirectDomainName
         Origins:
-        - DomainName: !Sub '${S3BucketRedirect}.s3-website-${AWS::Region}.amazonaws.com'
+        - DomainName: !Select [ 2, !Split [ /, !GetAtt S3BucketRedirect.WebsiteURL ] ]
           Id: s3origin
           CustomOriginConfig:
             OriginProtocolPolicy: 'http-only'


### PR DESCRIPTION
The string concatenation used to form the origin domain name and path in CloudFront is broken for regions that use the .region instead of the -region format (Ohio, Canada, Mumbai, Seoul, Frankfurt and London)

http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html
The two general forms of an Amazon S3 website endpoint are as follows:
bucket-name.s3-website-region.amazonaws.com (dash region)
bucket-name.s3-website.region.amazonaws.com (dot region)

Listing of all region endpoints
http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints

This is a particularly fun error to debug as CloudFront will error saying that it can't reach the origin server and when you look at the path it looks right on first glance (long string with only a dot/dash in the middle difference). I first ran into the problem several months back on a different project and started going down the road of a region map solution but think the path sub-select is certainly a lot shorter solution.

Fix Credit: https://github.com/ks888/LambStatus/pull/35/commits/ca4365189c054c5c90434453b92e75ceff0937e0