### PR TITLE
Make CloudTrail and Config External Bucket optional

### DIFF
--- a/security/cloudtrail.yaml
+++ b/security/cloudtrail.yaml
@@ -19,6 +19,7 @@ Parameters:
   ExternalTrailBucket:
     Description: 'Optional The name of the Amazon S3 bucket where CloudTrail publishes log files. If you leave this empty, the Amazon S3 bucket is created for you.'
     Type: String
+    Default: ''
   LogFilePrefix:
     Description: 'Optional The log file prefix.'
     Type: String

--- a/security/config.yaml
+++ b/security/config.yaml
@@ -23,6 +23,7 @@ Parameters:
   ExternalConfigBucket:
     Description: 'Optional The name of an S3 bucket where you want to store configuration history for the delivery channel. If you leave this empty, the Amazon S3 bucket is created for you.'
     Type: String
+    Default: ''
 Conditions:
   InternalBucket: !Equals [!Ref ExternalConfigBucket, '']
   ExternalBucket: !Not [!Equals [!Ref ExternalConfigBucket, '']]


### PR DESCRIPTION
The External Bucket Parameters weren't set up with a default, thus they weren't optional.