### PR TITLE
fix ssh bastion authorization

### DIFF
--- a/vpc/vpc-ssh-bastion.yaml
+++ b/vpc/vpc-ssh-bastion.yaml
@@ -290,10 +290,10 @@ Resources:
                   exit 1
                 fi
                 SaveUserName="$1"
-                SaveUserName=${SaveUserName//"+"/".plus."}
-                SaveUserName=${SaveUserName//"="/".equal."}
-                SaveUserName=${SaveUserName//","/".comma."}
-                SaveUserName=${SaveUserName//"@"/".at."}
+                SaveUserName=${SaveUserName//".plus."/"+"}
+                SaveUserName=${SaveUserName//".equal."/"="}
+                SaveUserName=${SaveUserName//".comma."/","}
+                SaveUserName=${SaveUserName//".at."/"@"}
                 aws iam list-ssh-public-keys --user-name "$SaveUserName" --query "SSHPublicKeys[?Status == 'Active'].[SSHPublicKeyId]" --output text | while read KeyId; do
                   aws iam get-ssh-public-key --user-name "$SaveUserName" --ssh-public-key-id "$KeyId" --encoding SSH --query "SSHPublicKey.SSHPublicKeyBody" --output text
                 done


### PR DESCRIPTION
The authorizer script in the bastion is replacing symbols with string version, while it should do the opposite (I type ssh `my.at.email.com@host` to login as `my@email.com`). This pr changes the replacing in the authorizer