### PR TITLE
Fix SurgeQueueLength comparisonOperator value

### DIFF
--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -313,7 +313,7 @@ Resources:
       Statistic: Maximum
       Period: 60
       EvaluationPeriods: 512
-      ComparisonOperator: SurgeQueueLength
+      ComparisonOperator: GreaterThanThreshold
       Threshold: 0
       AlarmActions:
       - 'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'


### PR DESCRIPTION
Fix SurgeQueueLength comparisonOperator value

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml` and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

CloudFormation will end-up in a `CREATE_FAILED` status, because the `comparisonOperator` is set to the wrong value. 

This commit solves the error:

```
1 validation error detected: Value 'SurgeQueueLength' at 'comparisonOperator' failed to satisfy constraint: Member must satisfy enum value set: [GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold, GreaterThanOrEqualToThreshold]
```