### PR TITLE
Set logretention for Lambda LogGroup

### DIFF
--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1144,7 +1144,7 @@ Resources:
         - 'ECS Container Instance State Change'
       State: ENABLED
       Targets:
-      - Arn: !GetAtt 'SchedulableContainersLambda.Arn'
+      - Arn: !GetAtt 'SchedulableContainersLambdaV2.Arn'
         Id: lambda
   SchedulableContainersRuleFailedInvocationsTooHighAlarm:
     Condition: HasAlertTopic
@@ -1169,7 +1169,7 @@ Resources:
       ScheduleExpression: 'rate(1 minute)'
       State: ENABLED
       Targets:
-      - Arn: !GetAtt 'SchedulableContainersLambda.Arn'
+      - Arn: !GetAtt 'SchedulableContainersLambdaV2.Arn'
         Id: lambda
   SchedulableContainersCronFailedInvocationsTooHighAlarm:
     Condition: HasAlertTopic
@@ -1223,17 +1223,17 @@ Resources:
     Type: 'AWS::Lambda::Permission'
     Properties:
       Action: 'lambda:InvokeFunction'
-      FunctionName: !Ref SchedulableContainersLambda
+      FunctionName: !Ref SchedulableContainersLambdaV2
       Principal: 'events.amazonaws.com'
       SourceArn: !GetAtt 'SchedulableContainersRule.Arn'
   SchedulableContainersLambdaPermission2:
     Type: 'AWS::Lambda::Permission'
     Properties:
       Action: 'lambda:InvokeFunction'
-      FunctionName: !Ref SchedulableContainersLambda
+      FunctionName: !Ref SchedulableContainersLambdaV2
       Principal: 'events.amazonaws.com'
       SourceArn: !GetAtt 'SchedulableContainersCron.Arn'
-  SchedulableContainersLambda:
+  SchedulableContainersLambdaV2:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
@@ -1309,10 +1309,10 @@ Resources:
       Timeout: 60
   SchedulableContainersLogGroup:
     Type: AWS::Logs::LogGroup
-    DependsOn: SchedulableContainersLambda
+    DependsOn: SchedulableContainersLambdaV2
     DeletionPolicy: Retain
     Properties:
-      LogGroupName: !Join ['', [/aws/lambda/, !Ref 'SchedulableContainersLambda']]
+      LogGroupName: !Sub '/aws/lambda${SchedulableContainersLambdaV2}'
       RetentionInDays: !Ref LogsRetentionInDays
   SchedulableContainersLambdaErrorsTooHighAlarm:
     Condition: HasAlertTopic
@@ -1330,7 +1330,7 @@ Resources:
       - 'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'
       Dimensions:
       - Name: FunctionName
-        Value: !Ref SchedulableContainersLambda
+        Value: !Ref SchedulableContainersLambdaV2
   SchedulableContainersLambdaThrottlesTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'
@@ -1347,7 +1347,7 @@ Resources:
       - 'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'
       Dimensions:
       - Name: FunctionName
-        Value: !Ref SchedulableContainersLambda
+        Value: !Ref SchedulableContainersLambdaV2
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1307,6 +1307,13 @@ Resources:
       Role: !GetAtt 'SchedulableContainersLambdaRole.Arn'
       Runtime: 'nodejs6.10'
       Timeout: 60
+  SchedulableContainersLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: SchedulableContainersLambda
+    DeletionPolicy: Retain
+    Properties:
+      LogGroupName: !Join ['', [/aws/lambda/, !Ref 'SchedulableContainersLambda']]
+      RetentionInDays: !Ref LogsRetentionInDays
   SchedulableContainersLambdaErrorsTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'


### PR DESCRIPTION
**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml` and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

Hi there,

Adding log retention for the log group that is used by the Lambda lifecycle function.

This change might break updating the existing CloudFormation stack, because the log group is already created by a previous CloudFormation run. 

Decided to set the `DeletionPolicy` to `Retain`, so that log retention stays there if a stack is deleted (_CF's default behaviour is setting `Expire Events After` to `Never expire`_ ).

Greetz, Siert