### PR TITLE
Address restore from snapshot issues

### DIFF
--- a/state/rds-postgres.yaml
+++ b/state/rds-postgres.yaml
@@ -74,6 +74,7 @@ Parameters:
   DBName:
     Description: 'Name of the database (ignored when DBSnapshotIdentifier is set).'
     Type: String
+    Default: ''
   DBBackupRetentionPeriod:
     Description: 'The number of days to keep snapshots of the database.'
     Type: Number
@@ -96,7 +97,7 @@ Parameters:
     Type: String
     Default: postgres
   Encryption:
-    Description: 'Enable server side encryption using KMS CMK key.'
+    Description: 'Enable server side encryption using KMS CMK key (ignored if DBSnapshotIdentifier set).'
     Type: String
     Default: false
     AllowedValues: [true, false]
@@ -105,7 +106,9 @@ Conditions:
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
-  HasEncryption: !Equals [!Ref Encryption, true]
+  CreateKey: !And
+  - !Equals [!Ref DBSnapshotIdentifier, '']
+  - !Equals [!Ref Encryption, true]
 Resources:
   RecordSet:
     Condition: HasZone
@@ -145,7 +148,7 @@ Resources:
       SourceSecurityGroupId:
         'Fn::ImportValue': !Sub '${ParentSSHBastionStack}-SecurityGroup'
   Key:
-    Condition: HasEncryption
+    Condition: CreateKey
     Type: 'AWS::KMS::Key'
     Properties:
       KeyPolicy:
@@ -173,7 +176,7 @@ Resources:
               'kms:CallerAccount': !Ref 'AWS::AccountId'
               'kms:ViaService': !Sub 'rds.${AWS::Region}.amazonaws.com'
   KeyAlias:
-    Condition: HasEncryption
+    Condition: CreateKey
     Type: 'AWS::KMS::Alias'
     Properties:
       AliasName: !Sub 'alias/${AWS::StackName}'
@@ -195,19 +198,19 @@ Resources:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       CopyTagsToSnapshot: true
       DBInstanceClass: !Ref DBInstanceClass
-      DBName: !Ref DBName
+      DBName: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBName]
       DBSnapshotIdentifier: !If [HasDBSnapshotIdentifier, !Ref DBSnapshotIdentifier, !Ref 'AWS::NoValue']
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: postgres
       EngineVersion: '9.6.5'
-      KmsKeyId: !If [HasEncryption, !Ref Key, !Ref 'AWS::NoValue']
+      KmsKeyId: !If [CreateKey, !Ref Key, !Ref 'AWS::NoValue']
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
       MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
       MultiAZ: !Ref DBMultiAZ
       PreferredBackupWindow: '09:54-10:24'
       PreferredMaintenanceWindow: 'sat:07:00-sat:07:30'
       StorageType: gp2
-      StorageEncrypted: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref Encryption]
+      StorageEncrypted: !If [CreateKey, true, !Ref 'AWS::NoValue']
       VPCSecurityGroups:
       - !Ref DatabaseSecurityGroup
   DatabaseBurstBalanceTooLowAlarm:

--- a/state/rds-postgres.yaml
+++ b/state/rds-postgres.yaml
@@ -86,6 +86,7 @@ Parameters:
   DBMasterUserPassword:
     Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set).'
     Type: String
+    Default: ''
     NoEcho: true
   DBMultiAZ:
     Description: 'Specifies if the database instance is deployed to multiple Availability Zones for HA.'
@@ -97,7 +98,7 @@ Parameters:
     Type: String
     Default: postgres
   Encryption:
-    Description: 'Enable server side encryption using KMS CMK key (ignored if DBSnapshotIdentifier set).'
+    Description: 'Enable server side encryption using a customer-managed KMS key (CMK) created by this template. (ignored if DBSnapshotIdentifier set).'
     Type: String
     Default: false
     AllowedValues: [true, false]
@@ -107,8 +108,8 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
   CreateKey: !And
-  - !Equals [!Ref DBSnapshotIdentifier, '']
   - !Equals [!Ref Encryption, true]
+  - !Not [!Condition HasDBSnapshotIdentifier]
 Resources:
   RecordSet:
     Condition: HasZone


### PR DESCRIPTION
This PR addresses a couple of issues related to creation of a DBInstance based on a provided `DBSnapshotIdentifier` parameter:

1. `DBName` is always expected by the template, but should not be passed to DBInstance when creating from a `DBSnapshotIdentifier` which will fail the stack create.
2. There is nothing to prevent a user supplying `Encrypted` when creating based off a `DBSnapshotIdentifier`, however at present this will cause the create to fail because the DBInstance's `StorageEncrypted` and `KmsKeyId` properties will be in conflict.

The change here causes `DBName` to be ignored and the creation and use of the KMS key to not happen where the DBInstance is being created from a snapshot.
