### PR TITLE
IPv6 support

### DIFF
--- a/ec2/ec2-auto-recovery.yaml
+++ b/ec2/ec2-auto-recovery.yaml
@@ -214,6 +214,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  SecurityGroupInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   SecurityGroupIngressTcpPort1:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasIngressTcpPort1
@@ -223,6 +232,15 @@ Resources:
       FromPort: !Ref IngressTcpPort1
       ToPort: !Ref IngressTcpPort1
       CidrIp: '0.0.0.0/0'
+  SecurityGroupIngressTcpPort1IPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasIngressTcpPort1
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: !Ref IngressTcpPort1
+      ToPort: !Ref IngressTcpPort1
+      CidrIpv6: '::/0'
   SecurityGroupIngressTcpPort2:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasIngressTcpPort2
@@ -232,6 +250,15 @@ Resources:
       FromPort: !Ref IngressTcpPort2
       ToPort: !Ref IngressTcpPort2
       CidrIp: '0.0.0.0/0'
+  SecurityGroupIngressTcpPort2IPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasIngressTcpPort2
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: !Ref IngressTcpPort2
+      ToPort: !Ref IngressTcpPort2
+      CidrIpv6: '::/0'
   SecurityGroupIngressTcpPort3:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasIngressTcpPort3
@@ -241,6 +268,15 @@ Resources:
       FromPort: !Ref IngressTcpPort3
       ToPort: !Ref IngressTcpPort3
       CidrIp: '0.0.0.0/0'
+  SecurityGroupIngressTcpPort3IPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasIngressTcpPort3
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: !Ref IngressTcpPort3
+      ToPort: !Ref IngressTcpPort3
+      CidrIpv6: '::/0'
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -332,6 +332,15 @@ Resources:
       FromPort: 80
       ToPort: 80
       CidrIp: '0.0.0.0/0'
+  ALBSecurityGroupInHttpWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroup
+    Properties:
+      GroupId: !Ref ALBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIpv6: '::/0'
   ALBSecurityGroupInHttpsWorld:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasNotAuthProxySecurityGroupAndLoadBalancerCertificateArn
@@ -341,6 +350,15 @@ Resources:
       FromPort: 443
       ToPort: 443
       CidrIp: '0.0.0.0/0'
+  ALBSecurityGroupInHttpsWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroupAndLoadBalancerCertificateArn
+    Properties:
+      GroupId: !Ref ALBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIpv6: '::/0'
   ALBSecurityGroupInHttpAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -391,6 +409,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  SecurityGroupInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   HTTPCodeELB5XXTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'
@@ -483,6 +510,7 @@ Resources:
         - ','
         - 'Fn::ImportValue':
             !Sub '${ParentVPCStack}-SubnetsPublic'
+      IpAddressType: dualstack
   DefaultTargetGroup: # this is used as the fall-back target group and is used to health checking the ECS agent. Services use their own ListenerRules to accept traffic based on path prefixes.
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -150,6 +150,15 @@ Resources:
       FromPort: 80
       ToPort: 80
       CidrIp: '0.0.0.0/0'
+  ALBSecurityGroupInHttpWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroup
+    Properties:
+      GroupId: !Ref ALBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIpv6: '::/0'
   ALBSecurityGroupInHttpsWorld:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasNotAuthProxySecurityGroupAndLoadBalancerCertificateArn
@@ -159,6 +168,15 @@ Resources:
       FromPort: 443
       ToPort: 443
       CidrIp: '0.0.0.0/0'
+  ALBSecurityGroupInHttpsWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroupAndLoadBalancerCertificateArn
+    Properties:
+      GroupId: !Ref ALBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIpv6: '::/0'
   ALBSecurityGroupInHttpAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -305,6 +323,7 @@ Resources:
         - ','
         - 'Fn::ImportValue':
             !Sub '${ParentVPCStack}-SubnetsPublic'
+      IpAddressType: dualstack
   HttpListener:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -305,6 +305,15 @@ Resources:
       FromPort: 80
       ToPort: 80
       CidrIp: '0.0.0.0/0'
+  MasterELBSGInWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroup
+    Properties:
+      GroupId: !Ref MasterELBSG
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIpv6: '::/0'
   MasterELBSGInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -413,6 +422,7 @@ Resources:
       Tags:
       - Key: Name
         Value: 'jenkins-master'
+      IpAddressType: dualstack
   MasterELBTargetGroup: # not monitored, but MasterELB is monitored!
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
@@ -570,6 +580,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  MasterSGInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSG
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   MasterLogs:
     Type: 'AWS::Logs::LogGroup'
     Properties:
@@ -1370,6 +1389,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  AgentSGInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref AgentSG
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   AgentLogs:
     Type: 'AWS::Logs::LogGroup'
     Properties:

--- a/jenkins/jenkins2-ha.yaml
+++ b/jenkins/jenkins2-ha.yaml
@@ -244,6 +244,15 @@ Resources:
       FromPort: 80
       ToPort: 80
       CidrIp: '0.0.0.0/0'
+  MasterELBSGInWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroup
+    Properties:
+      GroupId: !Ref MasterELBSG
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIpv6: '::/0'
   MasterELBSGInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -352,6 +361,7 @@ Resources:
       Tags:
       - Key: Name
         Value: 'jenkins-master'
+      IpAddressType: dualstack
   MasterELBTargetGroup:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
@@ -475,6 +485,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  MasterSGInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref MasterSG
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   MasterLogs:
     Type: 'AWS::Logs::LogGroup'
     Properties:

--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -157,9 +157,17 @@ Resources:
         ToPort: 80
         CidrIp: '0.0.0.0/0'
       - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIpv6: '::/0'
+      - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
         CidrIp: '0.0.0.0/0'
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIpv6: '::/0'
   HTTPCodeELB5XXTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'
@@ -256,6 +264,7 @@ Resources:
       Tags:
       - Key: Name
         Value: 'Auth proxy'
+      IpAddressType: dualstack
   LoadBalancerTargetGroup: # not monitored, but LoadBalancer is monitored!
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
@@ -358,6 +367,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  SecurityGroupInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:

--- a/static-website/static-website.yaml
+++ b/static-website/static-website.yaml
@@ -131,6 +131,7 @@ Resources:
           ViewerProtocolPolicy: 'redirect-to-https'
         Enabled: true
         HttpVersion: http2
+        IPV6Enabled: true
         PriceClass: 'PriceClass_All'
         ViewerCertificate:
           AcmCertificateArn: !If [HasCreateAcmCertificate, !Ref Certificate, !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref 'AWS::NoValue']]
@@ -199,6 +200,7 @@ Resources:
           ViewerProtocolPolicy: 'redirect-to-https'
         Enabled: true
         HttpVersion: http2
+        IPV6Enabled: true
         PriceClass: 'PriceClass_All'
         ViewerCertificate:
           AcmCertificateArn: !If [HasCreateAcmCertificate, !Ref Certificate, !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref 'AWS::NoValue']]

--- a/vpc/vpc-2azs-legacy.yaml
+++ b/vpc/vpc-2azs-legacy.yaml
@@ -23,6 +23,7 @@ Metadata:
       - AZA
       - AZB
       - ClassB
+      - Ipv6CidrBlock
       - VPC
       - SubnetAPublic
       - RouteTableAPublic
@@ -46,6 +47,10 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-255]'
     MinValue: 0
     MaxValue: 255
+  Ipv6CidrBlock:
+    Description: 'Optional set of IPv6 addresses for the VPC (e.g., 2600:1f18:277f:e700::/56, leave empty if VPC does not support IPv6).'
+    Type: String
+    Default: ''
   VPC:
     Description: 'VPC'
     Type: 'AWS::EC2::VPC::Id'
@@ -73,6 +78,8 @@ Parameters:
   RouteTableBPrivate:
     Description: 'Route table B private.'
     Type: String
+Conditions:
+  HasIPv6Support: !Not [!Equals [!Ref Ipv6CidrBlock, '']]
 Resources:
   Dummy:
     Type: 'AWS::S3::Bucket'
@@ -107,6 +114,12 @@ Outputs:
     Value: !Ref ClassB
     Export:
       Name: !Sub '${AWS::StackName}-ClassB'
+  Ipv6CidrBlock:
+    Description: 'The set of IPv6 addresses for the VPC.'
+    Condition: HasIPv6Support
+    Value: !Ref Ipv6CidrBlock
+    Export:
+      Name: !Sub '${AWS::StackName}-Ipv6CidrBlock'
   VPC:
     Description: 'VPC.'
     Value: !Ref VPC
@@ -182,3 +195,8 @@ Outputs:
     Value: !Ref RouteTableBPrivate
     Export:
       Name: !Sub '${AWS::StackName}-RouteTableBPrivate'
+  IPv6Support:
+    Description: 'IPv6 support.'
+    Value: !If [HasIPv6Support, true, false]
+    Export:
+      Name: !Sub '${AWS::StackName}-IPv6Support'

--- a/vpc/vpc-2azs.yaml
+++ b/vpc/vpc-2azs.yaml
@@ -21,6 +21,7 @@ Metadata:
         default: 'VPC Parameters'
       Parameters:
       - ClassB
+      - IPv6Support
 Parameters:
   ClassB:
     Description: 'Class B of VPC (10.XXX.0.0/16)'
@@ -29,6 +30,15 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-255]'
     MinValue: 0
     MaxValue: 255
+  IPv6Support:
+    Description: 'IPv6 support'
+    Type: String
+    AllowedValues:
+    - true
+    - false
+    Default: false
+Conditions:
+  HasIPv6Support: !Equals [!Ref IPv6Support, true]
 Resources:
   VPC:
     Type: 'AWS::EC2::VPC'
@@ -40,23 +50,37 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub '10.${ClassB}.0.0/16'
+  VPCCidrBlock:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::VPCCidrBlock'
+    Properties:
+      AmazonProvidedIpv6CidrBlock: true
+      VpcId: !Ref VPC
   InternetGateway:
     Type: 'AWS::EC2::InternetGateway'
     Properties:
       Tags:
       - Key: Name
         Value: !Sub '10.${ClassB}.0.0/16'
+  EgressOnlyInternetGateway:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::EgressOnlyInternetGateway'
+    Properties:
+      VpcId: !Ref VPC
   VPCGatewayAttachment:
     Type: 'AWS::EC2::VPCGatewayAttachment'
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
   SubnetAPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.0.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [0, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 4, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -64,10 +88,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetAPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.16.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [1, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 4, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -75,11 +102,14 @@ Resources:
       - Key: Reach
         Value: private
   SubnetBPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.32.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [2, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 4, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -87,10 +117,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetBPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.48.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [3, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 4, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -152,6 +185,20 @@ Resources:
       RouteTableId: !Ref RouteTablePublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicAInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTablePublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateAInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTablePrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   RouteTablePublicBInternetRoute:
     Type: 'AWS::EC2::Route'
     DependsOn: VPCGatewayAttachment
@@ -159,6 +206,20 @@ Resources:
       RouteTableId: !Ref RouteTableBPublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicBInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableBPublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateBInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableBPrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   NetworkAclPublic:
     Type: 'AWS::EC2::NetworkAcl'
     Properties:
@@ -202,6 +263,16 @@ Resources:
       RuleAction: allow
       Egress: false
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryInPublicAllowAllIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPublic
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryOutPublicAllowAll:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -211,6 +282,16 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryOutPublicAllowAllIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPublic
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryInPrivateAllowVPC:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -220,6 +301,16 @@ Resources:
       RuleAction: allow
       Egress: false
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryInPrivateAllowVPCIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPrivate
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryOutPrivateAllowVPC:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -229,6 +320,16 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryOutPrivateAllowVPCIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPrivate
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      Ipv6CidrBlock: '::/0'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'
@@ -259,6 +360,12 @@ Outputs:
     Value: !Ref ClassB
     Export:
       Name: !Sub '${AWS::StackName}-ClassB'
+  Ipv6CidrBlock:
+    Description: 'The set of IPv6 addresses for the VPC.'
+    Condition: HasIPv6Support
+    Value: !Select [0, !GetAtt 'VPC.Ipv6CidrBlocks']
+    Export:
+      Name: !Sub '${AWS::StackName}-Ipv6CidrBlock'
   VPC:
     Description: 'VPC.'
     Value: !Ref VPC
@@ -334,3 +441,8 @@ Outputs:
     Value: !Ref RouteTableBPrivate
     Export:
       Name: !Sub '${AWS::StackName}-RouteTableBPrivate'
+  IPv6Support:
+    Description: 'IPv6 support.'
+    Value: !Ref IPv6Support
+    Export:
+      Name: !Sub '${AWS::StackName}-IPv6Support'

--- a/vpc/vpc-3azs-legacy.yaml
+++ b/vpc/vpc-3azs-legacy.yaml
@@ -24,6 +24,7 @@ Metadata:
       - AZB
       - AZC
       - ClassB
+      - Ipv6CidrBlock
       - VPC
       - SubnetAPublic
       - RouteTableAPublic
@@ -54,6 +55,10 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-255]'
     MinValue: 0
     MaxValue: 255
+  Ipv6CidrBlock:
+    Description: 'Optional set of IPv6 addresses for the VPC (e.g., 2600:1f18:277f:e700::/56, leave empty if VPC does not support IPv6).'
+    Type: String
+    Default: ''
   VPC:
     Description: 'VPC'
     Type: 'AWS::EC2::VPC::Id'
@@ -93,6 +98,8 @@ Parameters:
   RouteTableCPrivate:
     Description: 'Route table C private.'
     Type: String
+Conditions:
+  HasIPv6Support: !Not [!Equals [!Ref Ipv6CidrBlock, '']]
 Resources:
   Dummy:
     Type: 'AWS::S3::Bucket'
@@ -132,6 +139,12 @@ Outputs:
     Value: !Ref ClassB
     Export:
       Name: !Sub '${AWS::StackName}-ClassB'
+  Ipv6CidrBlock:
+    Description: 'The set of IPv6 addresses for the VPC.'
+    Condition: HasIPv6Support
+    Value: !Ref Ipv6CidrBlock
+    Export:
+      Name: !Sub '${AWS::StackName}-Ipv6CidrBlock'
   VPC:
     Description: 'VPC.'
     Value: !Ref VPC
@@ -227,3 +240,8 @@ Outputs:
     Value: !Ref RouteTableCPrivate
     Export:
       Name: !Sub '${AWS::StackName}-RouteTableCPrivate'
+  IPv6Support:
+    Description: 'IPv6 support.'
+    Value: !If [HasIPv6Support, true, false]
+    Export:
+      Name: !Sub '${AWS::StackName}-IPv6Support'

--- a/vpc/vpc-3azs.yaml
+++ b/vpc/vpc-3azs.yaml
@@ -21,6 +21,7 @@ Metadata:
         default: 'VPC Parameters'
       Parameters:
       - ClassB
+      - IPv6Support
 Parameters:
   ClassB:
     Description: 'Class B of VPC (10.XXX.0.0/16)'
@@ -29,6 +30,15 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-255]'
     MinValue: 0
     MaxValue: 255
+  IPv6Support:
+    Description: 'IPv6 support'
+    Type: String
+    AllowedValues:
+    - true
+    - false
+    Default: false
+Conditions:
+  HasIPv6Support: !Equals [!Ref IPv6Support, true]
 Resources:
   VPC:
     Type: 'AWS::EC2::VPC'
@@ -40,23 +50,37 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub '10.${ClassB}.0.0/16'
+  VPCCidrBlock:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::VPCCidrBlock'
+    Properties:
+      AmazonProvidedIpv6CidrBlock: true
+      VpcId: !Ref VPC
   InternetGateway:
     Type: 'AWS::EC2::InternetGateway'
     Properties:
       Tags:
       - Key: Name
         Value: !Sub '10.${ClassB}.0.0/16'
+  EgressOnlyInternetGateway:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::EgressOnlyInternetGateway'
+    Properties:
+      VpcId: !Ref VPC
   VPCGatewayAttachment:
     Type: 'AWS::EC2::VPCGatewayAttachment'
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
   SubnetAPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.0.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [0, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 6, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -64,10 +88,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetAPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.16.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [1, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 6, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -75,11 +102,14 @@ Resources:
       - Key: Reach
         Value: private
   SubnetBPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.32.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [2, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 6, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -87,10 +117,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetBPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.48.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [3, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 6, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -98,11 +131,14 @@ Resources:
       - Key: Reach
         Value: private
   SubnetCPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [2, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.64.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [4, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 6, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -110,10 +146,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetCPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [2, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.80.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [5, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 6, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -199,6 +238,20 @@ Resources:
       RouteTableId: !Ref RouteTablePublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicAInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTablePublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateAInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTablePrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   RouteTablePublicBInternetRoute:
     Type: 'AWS::EC2::Route'
     DependsOn: VPCGatewayAttachment
@@ -206,6 +259,20 @@ Resources:
       RouteTableId: !Ref RouteTableBPublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicBInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableBPublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateBInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableBPrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   RouteTablePublicCInternetRoute:
     Type: 'AWS::EC2::Route'
     DependsOn: VPCGatewayAttachment
@@ -213,6 +280,20 @@ Resources:
       RouteTableId: !Ref RouteTableCPublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicCInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableCPublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateCInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableCPrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   NetworkAclPublic:
     Type: 'AWS::EC2::NetworkAcl'
     Properties:
@@ -266,6 +347,16 @@ Resources:
       RuleAction: allow
       Egress: false
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryInPublicAllowAllIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPublic
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryOutPublicAllowAll:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -275,6 +366,16 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryOutPublicAllowAllIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPublic
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryInPrivateAllowVPC:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -284,6 +385,16 @@ Resources:
       RuleAction: allow
       Egress: false
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryInPrivateAllowVPCIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPrivate
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryOutPrivateAllowVPC:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -293,6 +404,16 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryOutPrivateAllowVPCIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPrivate
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      Ipv6CidrBlock: '::/0'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'
@@ -328,6 +449,12 @@ Outputs:
     Value: !Ref ClassB
     Export:
       Name: !Sub '${AWS::StackName}-ClassB'
+  Ipv6CidrBlock:
+    Description: 'The set of IPv6 addresses for the VPC.'
+    Condition: HasIPv6Support
+    Value: !Select [0, !GetAtt 'VPC.Ipv6CidrBlocks']
+    Export:
+      Name: !Sub '${AWS::StackName}-Ipv6CidrBlock'
   VPC:
     Description: 'VPC.'
     Value: !Ref VPC
@@ -423,3 +550,8 @@ Outputs:
     Value: !Ref RouteTableCPrivate
     Export:
       Name: !Sub '${AWS::StackName}-RouteTableCPrivate'
+  IPv6Support:
+    Description: 'IPv6 support.'
+    Value: !Ref IPv6Support
+    Export:
+      Name: !Sub '${AWS::StackName}-IPv6Support'

--- a/vpc/vpc-4azs-legacy.yaml
+++ b/vpc/vpc-4azs-legacy.yaml
@@ -25,6 +25,7 @@ Metadata:
       - AZC
       - AZD
       - ClassB
+      - Ipv6CidrBlock
       - VPC
       - SubnetAPublic
       - RouteTableAPublic
@@ -62,6 +63,10 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-255]'
     MinValue: 0
     MaxValue: 255
+  Ipv6CidrBlock:
+    Description: 'Optional set of IPv6 addresses for the VPC (e.g., 2600:1f18:277f:e700::/56, leave empty if VPC does not support IPv6).'
+    Type: String
+    Default: ''
   VPC:
     Description: 'VPC'
     Type: 'AWS::EC2::VPC::Id'
@@ -113,6 +118,8 @@ Parameters:
   RouteTableDPrivate:
     Description: 'Route table D private.'
     Type: String
+Conditions:
+  HasIPv6Support: !Not [!Equals [!Ref Ipv6CidrBlock, '']]
 Resources:
   Dummy:
     Type: 'AWS::S3::Bucket'
@@ -157,6 +164,12 @@ Outputs:
     Value: !Ref ClassB
     Export:
       Name: !Sub '${AWS::StackName}-ClassB'
+  Ipv6CidrBlock:
+    Description: 'The set of IPv6 addresses for the VPC.'
+    Condition: HasIPv6Support
+    Value: !Ref Ipv6CidrBlock
+    Export:
+      Name: !Sub '${AWS::StackName}-Ipv6CidrBlock'
   VPC:
     Description: 'VPC.'
     Value: !Ref VPC
@@ -272,3 +285,8 @@ Outputs:
     Value: !Ref RouteTableDPrivate
     Export:
       Name: !Sub '${AWS::StackName}-RouteTableDPrivate'
+  IPv6Support:
+    Description: 'IPv6 support.'
+    Value: !If [HasIPv6Support, true, false]
+    Export:
+      Name: !Sub '${AWS::StackName}-IPv6Support'

--- a/vpc/vpc-4azs.yaml
+++ b/vpc/vpc-4azs.yaml
@@ -21,6 +21,7 @@ Metadata:
         default: 'VPC Parameters'
       Parameters:
       - ClassB
+      - IPv6Support
 Parameters:
   ClassB:
     Description: 'Class B of VPC (10.XXX.0.0/16)'
@@ -29,6 +30,15 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-255]'
     MinValue: 0
     MaxValue: 255
+  IPv6Support:
+    Description: 'IPv6 support'
+    Type: String
+    AllowedValues:
+    - true
+    - false
+    Default: false
+Conditions:
+  HasIPv6Support: !Equals [!Ref IPv6Support, true]
 Resources:
   VPC:
     Type: 'AWS::EC2::VPC'
@@ -40,23 +50,37 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub '10.${ClassB}.0.0/16'
+  VPCCidrBlock:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::VPCCidrBlock'
+    Properties:
+      AmazonProvidedIpv6CidrBlock: true
+      VpcId: !Ref VPC
   InternetGateway:
     Type: 'AWS::EC2::InternetGateway'
     Properties:
       Tags:
       - Key: Name
         Value: !Sub 10.${ClassB}.0.0/16
+  EgressOnlyInternetGateway:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::EgressOnlyInternetGateway'
+    Properties:
+      VpcId: !Ref VPC
   VPCGatewayAttachment:
     Type: 'AWS::EC2::VPCGatewayAttachment'
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
   SubnetAPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.0.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [0, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -64,10 +88,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetAPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.16.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [1, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -75,11 +102,14 @@ Resources:
       - Key: Reach
         Value: private
   SubnetBPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.32.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [2, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -87,10 +117,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetBPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [1, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.48.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [3, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -98,11 +131,14 @@ Resources:
       - Key: Reach
         Value: private
   SubnetCPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [2, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.64.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [4, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -110,10 +146,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetCPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [2, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.80.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [5, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -121,11 +160,14 @@ Resources:
       - Key: Reach
         Value: private
   SubnetDPublic:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [3, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.96.0/20'
-      MapPublicIpOnLaunch: true
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [6, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
+      # TODO CFN bug? MapPublicIpOnLaunch and AssignIpv6AddressOnCreation can not be true at the same time MapPublicIpOnLaunch: true
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -133,10 +175,13 @@ Resources:
       - Key: Reach
         Value: public
   SubnetDPrivate:
+    DependsOn: VPCCidrBlock # TODO CFN bug? why can I not get the Ipv6CidrBlocks from the VPCCidrBlock resource? instead I have to ask the VPC resource...
     Type: 'AWS::EC2::Subnet'
     Properties:
+      AssignIpv6AddressOnCreation: !If [HasIPv6Support, true, false]
       AvailabilityZone: !Select [3, !GetAZs '']
       CidrBlock: !Sub '10.${ClassB}.112.0/20'
+      Ipv6CidrBlock: !If [HasIPv6Support, !Select [7, !Cidr [!Select [0, !GetAtt 'VPC.Ipv6CidrBlocks'], 8, 64]], !Ref 'AWS::NoValue']
       VpcId: !Ref VPC
       Tags:
       - Key: Name
@@ -246,6 +291,20 @@ Resources:
       RouteTableId: !Ref RouteTablePublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicAInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTablePublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateAInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTablePrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   RouteTablePublicBInternetRoute:
     Type: 'AWS::EC2::Route'
     DependsOn: VPCGatewayAttachment
@@ -253,6 +312,20 @@ Resources:
       RouteTableId: !Ref RouteTableBPublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicBInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableBPublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateBInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableBPrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   RouteTablePublicCInternetRoute:
     Type: 'AWS::EC2::Route'
     DependsOn: VPCGatewayAttachment
@@ -260,6 +333,20 @@ Resources:
       RouteTableId: !Ref RouteTableCPublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicCInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableCPublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateCInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableCPrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   RouteTablePublicDInternetRoute:
     Type: 'AWS::EC2::Route'
     DependsOn: VPCGatewayAttachment
@@ -267,6 +354,20 @@ Resources:
       RouteTableId: !Ref RouteTableDPublic
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
+  RouteTablePublicDInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableDPublic
+      DestinationIpv6CidrBlock: '::/0'
+      GatewayId: !Ref InternetGateway
+  RouteTablePrivateDInternetRouteIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::Route'
+    Properties:
+      RouteTableId: !Ref RouteTableDPrivate
+      DestinationIpv6CidrBlock: '::/0'
+      EgressOnlyInternetGatewayId: !Ref EgressOnlyInternetGateway
   NetworkAclPublic:
     Type: 'AWS::EC2::NetworkAcl'
     Properties:
@@ -330,6 +431,16 @@ Resources:
       RuleAction: allow
       Egress: false
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryInPublicAllowAllIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPublic
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryOutPublicAllowAll:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -339,6 +450,16 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryOutPublicAllowAllIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPublic
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryInPrivateAllowVPC:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -348,6 +469,16 @@ Resources:
       RuleAction: allow
       Egress: false
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryInPrivateAllowVPCIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPrivate
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      Ipv6CidrBlock: '::/0'
   NetworkAclEntryOutPrivateAllowVPC:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
@@ -357,6 +488,16 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  NetworkAclEntryOutPrivateAllowVPCIPv6:
+    Condition: HasIPv6Support
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref NetworkAclPrivate
+      RuleNumber: 98
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      Ipv6CidrBlock: '::/0'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'
@@ -397,6 +538,12 @@ Outputs:
     Value: !Ref ClassB
     Export:
       Name: !Sub '${AWS::StackName}-ClassB'
+  Ipv6CidrBlock:
+    Description: 'The set of IPv6 addresses for the VPC.'
+    Condition: HasIPv6Support
+    Value: !Select [0, !GetAtt 'VPC.Ipv6CidrBlocks']
+    Export:
+      Name: !Sub '${AWS::StackName}-Ipv6CidrBlock'
   VPC:
     Description: 'VPC.'
     Value: !Ref VPC
@@ -512,3 +659,8 @@ Outputs:
     Value: !Ref RouteTableDPrivate
     Export:
       Name: !Sub '${AWS::StackName}-RouteTableDPrivate'
+  IPv6Support:
+    Description: 'IPv6 support.'
+    Value: !Ref IPv6Support
+    Export:
+      Name: !Sub '${AWS::StackName}-IPv6Support'

--- a/vpc/vpc-nat-instance.yaml
+++ b/vpc/vpc-nat-instance.yaml
@@ -208,6 +208,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  NATSecurityGroupInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref NATSecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   NATInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:

--- a/vpc/vpc-ssh-bastion.yaml
+++ b/vpc/vpc-ssh-bastion.yaml
@@ -140,6 +140,10 @@ Resources:
         FromPort: 22
         ToPort: 22
         CidrIp: '0.0.0.0/0'
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIpv6: '::/0'
       VpcId:
         'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'
   InstanceProfile:

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -194,6 +194,15 @@ Resources:
       FromPort: 443
       ToPort: 443
       CidrIp: '0.0.0.0/0'
+  LoadBalancerSecurityGroupInWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroup
+    Properties:
+      GroupId: !Ref LoadBalancerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIpv6: '::/0'
   LoadBalancerSecurityGroupInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -234,6 +243,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  WebServerSecurityGroupInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref WebServerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   DatabaseSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -333,6 +351,7 @@ Resources:
       SecurityGroups:
       - !Ref LoadBalancerSecurityGroup
       Scheme: 'internet-facing'
+      IpAddressType: dualstack
   LoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -1074,6 +1093,7 @@ Resources:
           Compress: true
         Enabled: true
         HttpVersion: http2
+        IPV6Enabled: true
         PriceClass: 'PriceClass_All'
         ViewerCertificate:
           AcmCertificateArn: !Ref CloudFrontAcmCertificate

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -194,6 +194,15 @@ Resources:
       FromPort: 443
       ToPort: 443
       CidrIp: '0.0.0.0/0'
+  LoadBalancerSecurityGroupInWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotAuthProxySecurityGroup
+    Properties:
+      GroupId: !Ref LoadBalancerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIpv6: '::/0'
   LoadBalancerSecurityGroupInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -234,6 +243,15 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: '0.0.0.0/0'
+  WebServerSecurityGroupInSSHWorldIPv6:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasNotSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref WebServerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIpv6: '::/0'
   DatabaseSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -1051,6 +1069,7 @@ Resources:
           Compress: true
         Enabled: true
         HttpVersion: http2
+        IPV6Enabled: true
         PriceClass: 'PriceClass_All'
         ViewerCertificate:
           AcmCertificateArn: !Ref CloudFrontAcmCertificate


### PR DESCRIPTION
Templates that need adjustment:

- [x] `ec2/ec2-auto-recovery.yaml`
- [x] `ecs/cluster.yaml`
- [x] `ecs/service-cluster-alb.yaml`
- [x] `ecs/service-dedicated-alb.yaml`
- [x] `jenkins/jenkins2-ha-agents.yaml`
- [x] `jenkins/jenkins2-ha.yaml`
- [x] `security/auth-proxy-ha-github-orga.yaml`
- [x] `static-website/static-website.yaml`
- [x] `vpc/vpc-2azs-legacy.yaml`
- [x] `vpc/vpc-2azs.yaml`
- [x] `vpc/vpc-3azs-legacy.yaml`
- [x] `vpc/vpc-3azs.yaml`
- [x] `vpc/vpc-4azs-legacy.yaml`
- [x] `vpc/vpc-4azs.yaml`
- [x] `vpc/vpc-nat-instance.yaml`
- [x] `vpc/vpc-ssh-bastion.yaml`
- [x] `wordpress/wordpress-ha-aurora.yaml`
- [x] `wordpress/wordpress-ha.yaml`
- [ ] Test suite passes

Waiting for AWS:

- [ ] `vpc/vpc-2azs.yaml`
- [ ] `vpc/vpc-3azs.yaml`
- [ ] `vpc/vpc-4azs.yaml`