### PR TITLE
[Improvement] wordpress/* - Enable xmlrpc for WordPress API

### DIFF
--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -764,6 +764,7 @@ Resources:
               php-opcache: []
               php-mysqlnd: []
               php-mbstring: []
+              php-xmlrpc: []
               mariadb: []
               httpd: []
           files:

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -752,6 +752,7 @@ Resources:
               php-opcache: []
               php-mysqlnd: []
               php-mbstring: []
+              php-xmlrpc: []
               mariadb: []
               httpd: []
           files:


### PR DESCRIPTION
Makes the wordpress templates have the machines install php-xmlrpc so that the xmlrpc api of wordpress is usable
