### PR TITLE
[Improvement] wordpress/* -  Optional EFS provisioned throughout

### DIFF
--- a/test/src/test/java/de/widdix/awscftemplates/wordpress/TestWordpressHA.java
+++ b/test/src/test/java/de/widdix/awscftemplates/wordpress/TestWordpressHA.java
@@ -76,6 +76,70 @@ public class TestWordpressHA extends ACloudFormationTest {
     }
 
     @Test
+    public void testMySQLWithEFSProvisionedThroughput() {
+        final String zoneStackName = "zone-" + this.random8String();
+        final String vpcStackName = "vpc-2azs-" + this.random8String();
+        final String stackName = "wordpress-ha-" + this.random8String();
+        final String classB = "10";
+        final String keyName = "key-" + this.random8String();
+        final String subDomainName = stackName;
+        final String blogTitle = "Stay-AWSome";
+        final String blogPassword = this.random8String();
+        try {
+            this.createKey(keyName);
+            try {
+                this.createStack(zoneStackName,
+                        "vpc/zone-legacy.yaml",
+                        new Parameter().withParameterKey("HostedZoneName").withParameterValue(Config.get(Config.Key.DOMAIN_SUFFIX)),
+                        new Parameter().withParameterKey("HostedZoneId").withParameterValue(Config.get(Config.Key.HOSTED_ZONE_ID))
+                );
+                try {
+                    this.createStack(vpcStackName,
+                            "vpc/vpc-2azs.yaml",
+                            new Parameter().withParameterKey("ClassB").withParameterValue(classB)
+                    );
+                    try {
+                        this.createStack(stackName,
+                                "wordpress/wordpress-ha.yaml",
+                                new Parameter().withParameterKey("ParentVPCStack").withParameterValue(vpcStackName),
+                                new Parameter().withParameterKey("ParentZoneStack").withParameterValue(zoneStackName),
+                                new Parameter().withParameterKey("WebServerKeyName").withParameterValue(keyName),
+                                new Parameter().withParameterKey("SubDomainNameWithDot").withParameterValue(subDomainName + "."),
+                                new Parameter().withParameterKey("CloudFrontAcmCertificate").withParameterValue(Config.get(Config.Key.CLOUDFRONT_ACM_CERTIFICATE_ARN)),
+                                new Parameter().withParameterKey("ElbAcmCertificate").withParameterValue(Config.get(Config.Key.ACM_CERTIFICATE_ARN)),
+                                new Parameter().withParameterKey("BlogTitle").withParameterValue(blogTitle),
+                                new Parameter().withParameterKey("BlogAdminUsername").withParameterValue("admin"),
+                                new Parameter().withParameterKey("BlogAdminPassword").withParameterValue(blogPassword),
+                                new Parameter().withParameterKey("BlogAdminEMail").withParameterValue("no-reply@widdix.de"),
+                                new Parameter().withParameterKey("EFSProvisionedThroughputInMibps").withParameterValue("1.0")
+                        );
+                        final String url = "https://" + subDomainName + "." + Config.get(Config.Key.DOMAIN_SUFFIX);
+                        final Callable<String> callable = () -> {
+                            final HttpResponse response = WS.url(url).timeout(10000).get();
+                            // check HTTP response code
+                            if (WS.getStatus(response) != 200) {
+                                throw new RuntimeException("200 expected, but saw " + WS.getStatus(response));
+                            }
+                            return WS.getResponseAsString(response);
+                        };
+                        final String response = this.retry(callable);
+                        // check if blog title appears in HTML
+                        Assert.assertTrue(response.contains(blogTitle));
+                    } finally {
+                        this.deleteStackAndRetryOnFailure(stackName);
+                    }
+                } finally {
+                    this.deleteStack(vpcStackName);
+                }
+            } finally {
+                this.deleteStack(zoneStackName);
+            }
+        } finally {
+            this.deleteKey(keyName);
+        }
+    }
+
+    @Test
     public void testAurora() {
         final String zoneStackName = "zone-" + this.random8String();
         final String vpcStackName = "vpc-3azs-" + this.random8String();
@@ -111,6 +175,70 @@ public class TestWordpressHA extends ACloudFormationTest {
                                 new Parameter().withParameterKey("BlogAdminUsername").withParameterValue("admin"),
                                 new Parameter().withParameterKey("BlogAdminPassword").withParameterValue(blogPassword),
                                 new Parameter().withParameterKey("BlogAdminEMail").withParameterValue("no-reply@widdix.de")
+                        );
+                        final String url = "https://" + subDomainName + "." + Config.get(Config.Key.DOMAIN_SUFFIX);
+                        final Callable<String> callable = () -> {
+                            final HttpResponse response = WS.url(url).timeout(10000).get();
+                            // check HTTP response code
+                            if (WS.getStatus(response) != 200) {
+                                throw new RuntimeException("200 expected, but saw " + WS.getStatus(response));
+                            }
+                            return WS.getResponseAsString(response);
+                        };
+                        final String response = this.retry(callable);
+                        // check if blog title appears in HTML
+                        Assert.assertTrue(response.contains(blogTitle));
+                    } finally {
+                        this.deleteStackAndRetryOnFailure(stackName);
+                    }
+                } finally {
+                    this.deleteStack(vpcStackName);
+                }
+            } finally {
+                this.deleteStack(zoneStackName);
+            }
+        } finally {
+            this.deleteKey(keyName);
+        }
+    }
+
+    @Test
+    public void testAuroraWithEFSProvisionedThroughput() {
+        final String zoneStackName = "zone-" + this.random8String();
+        final String vpcStackName = "vpc-3azs-" + this.random8String();
+        final String stackName = "wordpress-ha-aurora" + this.random8String();
+        final String classB = "10";
+        final String keyName = "key-" + this.random8String();
+        final String subDomainName = stackName;
+        final String blogTitle = "Stay-AWSome";
+        final String blogPassword = this.random8String();
+        try {
+            this.createKey(keyName);
+            try {
+                this.createStack(zoneStackName,
+                        "vpc/zone-legacy.yaml",
+                        new Parameter().withParameterKey("HostedZoneName").withParameterValue(Config.get(Config.Key.DOMAIN_SUFFIX)),
+                        new Parameter().withParameterKey("HostedZoneId").withParameterValue(Config.get(Config.Key.HOSTED_ZONE_ID))
+                );
+                try {
+                    this.createStack(vpcStackName,
+                            "vpc/vpc-3azs.yaml",
+                            new Parameter().withParameterKey("ClassB").withParameterValue(classB)
+                    );
+                    try {
+                        this.createStack(stackName,
+                                "wordpress/wordpress-ha-aurora.yaml",
+                                new Parameter().withParameterKey("ParentVPCStack").withParameterValue(vpcStackName),
+                                new Parameter().withParameterKey("ParentZoneStack").withParameterValue(zoneStackName),
+                                new Parameter().withParameterKey("WebServerKeyName").withParameterValue(keyName),
+                                new Parameter().withParameterKey("SubDomainNameWithDot").withParameterValue(subDomainName + "."),
+                                new Parameter().withParameterKey("CloudFrontAcmCertificate").withParameterValue(Config.get(Config.Key.CLOUDFRONT_ACM_CERTIFICATE_ARN)),
+                                new Parameter().withParameterKey("ElbAcmCertificate").withParameterValue(Config.get(Config.Key.ACM_CERTIFICATE_ARN)),
+                                new Parameter().withParameterKey("BlogTitle").withParameterValue(blogTitle),
+                                new Parameter().withParameterKey("BlogAdminUsername").withParameterValue("admin"),
+                                new Parameter().withParameterKey("BlogAdminPassword").withParameterValue(blogPassword),
+                                new Parameter().withParameterKey("BlogAdminEMail").withParameterValue("no-reply@widdix.de"),
+                                new Parameter().withParameterKey("EFSProvisionedThroughputInMibps").withParameterValue("1.0")
                         );
                         final String url = "https://" + subDomainName + "." + Config.get(Config.Key.DOMAIN_SUFFIX);
                         final Callable<String> callable = () -> {

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -126,9 +126,9 @@ Parameters:
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
   EFSProvisionedThroughputInMibps:
-    Description: 'The provisioned throughput for the Elastic File System (EFS) in Mibps. Default is 0.0 which enables the bursting mode and disables provisioned throughput.'
+    Description: 'The provisioned throughput for the Elastic File System (EFS) in Mibps. Default is 0 which enables the bursting mode and disables provisioned throughput.'
     Type: Number
-    Default: 0.0
+    Default: 0
   DBServerInstanceType:
     Description: 'The instance type of database server (e.g. db.t2.small).'
     Type: String
@@ -189,8 +189,8 @@ Conditions:
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
   HasNotAuthProxySecurityGroup: !Equals [!Ref ParentAuthProxyStack, '']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
-  HasEFSProvisionedThroughput: !Not [!Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']]
-  HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']
+  HasEFSProvisionedThroughput: !Not [!Equals [!Ref EFSProvisionedThroughputInMibps, '0']]
+  HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0']
   HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
   HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
 Resources:

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -47,6 +47,10 @@ Metadata:
       - WebServerInstanceType
       - WebServerLogsRetentionInDays
     - Label:
+        default: 'EFS Parameters'
+      Parameters:
+      - EFSProvisionedThroughputInMibps
+    - Label:
         default: 'Database Parameters'
       Parameters:
       - DBServerInstanceType
@@ -121,6 +125,10 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  EFSProvisionedThroughputInMibps:
+    Description: 'The provisioned throughput for the Elastic File System (EFS) in Mibps. Default is 0.0 which enables the bursting mode and disables provisioned throughput.'
+    Type: Number
+    Default: 0.0
   DBServerInstanceType:
     Description: 'The instance type of database server (e.g. db.t2.small).'
     Type: String
@@ -181,6 +189,10 @@ Conditions:
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
   HasNotAuthProxySecurityGroup: !Equals [!Ref ParentAuthProxyStack, '']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasEFSProvisionedThroughput: !Not [!Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']]
+  HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']
+  HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
+  HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
 Resources:
   WebServerLogs:
     Type: 'AWS::Logs::LogGroup'
@@ -989,28 +1001,13 @@ Resources:
   EFSFileSystem:
     Type: 'AWS::EFS::FileSystem'
     Properties:
+      ThroughputMode: !If [HasEFSProvisionedThroughput, 'provisioned', 'bursting']
+      ProvisionedThroughputInMibps: !If [HasEFSProvisionedThroughput, !Ref EFSProvisionedThroughputInMibps, !Ref 'AWS::NoValue']
       FileSystemTags:
       - Key: Name
         Value: !Sub '${AWS::StackName}-efs'
-  EFSFileSystemPercentIOLimitTooHighAlarm:
-    Condition: HasAlertTopic
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Average IO utilization over last 10 minutes higher than 80%'
-      Namespace: 'AWS/EFS'
-      MetricName: PercentIOLimit
-      Statistic: Average
-      Period: 600
-      EvaluationPeriods: 1
-      ComparisonOperator: GreaterThanThreshold
-      Threshold: 80
-      AlarmActions:
-      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
-      Dimensions:
-      - Name: FileSystemId
-        Value: !Ref EFSFileSystem
   EFSFileSystemBurstCreditBalanceTooLowAlarm:
-    Condition: HasAlertTopic
+    Condition: HasAlertTopicAndNotEFSProvisionedThroughput
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       AlarmDescription: 'EFS file system is running out of burst credits. You can expect a significant performance drop in the next hour.'
@@ -1021,6 +1018,23 @@ Resources:
       EvaluationPeriods: 1
       ComparisonOperator: LessThanThreshold
       Threshold: 192416666667 # 192 GB in Bytes (last hour where you can burst at 100 MB/sec)
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+      Dimensions:
+      - Name: FileSystemId
+        Value: !Ref EFSFileSystem
+  EFSFileSystemThroughputAlarm:
+    Condition: HasAlertTopicAndEFSProvisionedThroughput
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Reached 90% of the provisioned throughput within a period of 10 minutes.'
+      Namespace: 'AWS/EFS'
+      MetricName: TotalIOBytes
+      Statistic: Sum
+      Period: 600
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: !GetAtt MaxThroughputCalculator.Threshold
       AlarmActions:
       - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
       Dimensions:
@@ -1057,6 +1071,49 @@ Resources:
         FromPort: 2049
         ToPort: 2049
         SourceSecurityGroupId: !Ref WebServerSecurityGroup
+  LambdaRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action:
+          - 'sts:AssumeRole'
+      Path: '/'
+      ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  LambdaFunction: # needs no monitoring because it is used as a custom resource
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code:
+        ZipFile: |
+          'use strict';
+          const response = require('cfn-response');
+          exports.handler = (event, context, cb) => {
+            const throughput = parseInt(event.ResourceProperties.ThroughputInMibps, 10);
+            const threshold = Math.round(throughput * 1048576 * 600 * 0.9);
+            response.send(event, context, response.SUCCESS, {Threshold: threshold});
+          };
+      Handler: 'index.handler'
+      MemorySize: 128
+      Role: !GetAtt 'LambdaRole.Arn'
+      Runtime: 'nodejs6.10'
+      Timeout: 60
+  LambdaLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${LambdaFunction}'
+      RetentionInDays: !Ref WebServerLogsRetentionInDays
+  MaxThroughputCalculator:
+    Type: 'Custom::MaxThroughputCalculator'
+    DependsOn: LambdaLogGroup
+    Version: '1.0'
+    Properties:
+      ThroughputInMibps: !Ref EFSProvisionedThroughputInMibps
+      ServiceToken: !GetAtt 'LambdaFunction.Arn'
   RecordSet:
     Type: 'AWS::Route53::RecordSet'
     Properties:

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -192,7 +192,7 @@ Conditions:
   HasEFSProvisionedThroughput: !Not [!Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']]
   HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']
   HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
-  HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]  
+  HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
 Resources:
   WebServerLogs:
     Type: 'AWS::Logs::LogGroup'

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -47,6 +47,10 @@ Metadata:
       - WebServerInstanceType
       - WebServerLogsRetentionInDays
     - Label:
+        default: 'EFS Parameters'
+      Parameters:
+      - EFSProvisionedThroughputInMibps
+    - Label:
         default: 'Database Parameters'
       Parameters:
       - DBServerInstanceType
@@ -121,6 +125,10 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  EFSProvisionedThroughputInMibps:
+    Description: 'The provisioned throughput for the Elastic File System (EFS) in Mibps. Default is 0.0 which enables the bursting mode and disables provisioned throughput.'
+    Type: Number
+    Default: 0.0
   DBServerInstanceType:
     Description: 'The instance type of database server (e.g. db.t2.micro).'
     Type: String
@@ -181,6 +189,10 @@ Conditions:
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
   HasNotAuthProxySecurityGroup: !Equals [!Ref ParentAuthProxyStack, '']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasEFSProvisionedThroughput: !Not [!Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']]
+  HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']
+  HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
+  HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]  
 Resources:
   WebServerLogs:
     Type: 'AWS::Logs::LogGroup'
@@ -975,28 +987,13 @@ Resources:
   EFSFileSystem:
     Type: 'AWS::EFS::FileSystem'
     Properties:
+      ThroughputMode: !If [HasEFSProvisionedThroughput, 'provisioned', 'bursting']
+      ProvisionedThroughputInMibps: !If [HasEFSProvisionedThroughput, !Ref EFSProvisionedThroughputInMibps, !Ref 'AWS::NoValue']
       FileSystemTags:
       - Key: Name
         Value: !Sub '${AWS::StackName}-efs'
-  EFSFileSystemPercentIOLimitTooHighAlarm:
-    Condition: HasAlertTopic
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Average IO utilization over last 10 minutes higher than 80%'
-      Namespace: 'AWS/EFS'
-      MetricName: PercentIOLimit
-      Statistic: Average
-      Period: 600
-      EvaluationPeriods: 1
-      ComparisonOperator: GreaterThanThreshold
-      Threshold: 80
-      AlarmActions:
-      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
-      Dimensions:
-      - Name: FileSystemId
-        Value: !Ref EFSFileSystem
   EFSFileSystemBurstCreditBalanceTooLowAlarm:
-    Condition: HasAlertTopic
+    Condition: HasAlertTopicAndNotEFSProvisionedThroughput
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
       AlarmDescription: 'EFS file system is running out of burst credits. You can expect a significant performance drop in the next hour.'
@@ -1007,6 +1004,23 @@ Resources:
       EvaluationPeriods: 1
       ComparisonOperator: LessThanThreshold
       Threshold: 192416666667 # 192 GB in Bytes (last hour where you can burst at 100 MB/sec)
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+      Dimensions:
+      - Name: FileSystemId
+        Value: !Ref EFSFileSystem
+  EFSFileSystemThroughputAlarm:
+    Condition: HasAlertTopicAndEFSProvisionedThroughput
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Reached 90% of the provisioned throughput within a period of 10 minutes.'
+      Namespace: 'AWS/EFS'
+      MetricName: TotalIOBytes
+      Statistic: Sum
+      Period: 600
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: !GetAtt MaxThroughputCalculator.Threshold
       AlarmActions:
       - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
       Dimensions:
@@ -1036,6 +1050,49 @@ Resources:
         FromPort: 2049
         ToPort: 2049
         SourceSecurityGroupId: !Ref WebServerSecurityGroup
+  LambdaRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action:
+          - 'sts:AssumeRole'
+      Path: '/'
+      ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  LambdaFunction: # needs no monitoring because it is used as a custom resource
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code:
+        ZipFile: |
+          'use strict';
+          const response = require('cfn-response');
+          exports.handler = (event, context, cb) => {
+            const throughput = parseInt(event.ResourceProperties.ThroughputInMibps, 10);
+            const threshold = Math.round(throughput * 1048576 * 600 * 0.9);
+            response.send(event, context, response.SUCCESS, {Threshold: threshold});
+          };
+      Handler: 'index.handler'
+      MemorySize: 128
+      Role: !GetAtt 'LambdaRole.Arn'
+      Runtime: 'nodejs6.10'
+      Timeout: 60
+  LambdaLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${LambdaFunction}'
+      RetentionInDays: !Ref WebServerLogsRetentionInDays
+  MaxThroughputCalculator:
+    Type: 'Custom::MaxThroughputCalculator'
+    DependsOn: LambdaLogGroup
+    Version: '1.0'
+    Properties:
+      ThroughputInMibps: !Ref EFSProvisionedThroughputInMibps
+      ServiceToken: !GetAtt 'LambdaFunction.Arn'
   RecordSet:
     Type: 'AWS::Route53::RecordSet'
     Properties:


### PR DESCRIPTION
As CloudFormation allows us to use EFS provisioned throughput now, I've added an optional parameter  `EFSProvisionedThroughputInMibps`.

A Custom Resource is used to calculate the threshold for the CloudWatch alarm.