### PR TITLE
Increase password length to match API tokens

### DIFF
--- a/jenkins/jenkins2-ha.yaml
+++ b/jenkins/jenkins2-ha.yaml
@@ -101,7 +101,7 @@ Parameters:
     Type: String
     NoEcho: true
     MinLength: 8
-    MaxLength: 32
+    MaxLength: 34
   MasterLogsRetentionInDays:
     Description: 'Specifies the number of days you want to retain log events in the specified log group.'
     Type: Number


### PR DESCRIPTION
When Jenkins is configured for another authentication provider (i.e. SAML), the existing admin login is invalidated. To work around this, an API token can be generated for the admin user. These tokens are 34 characters in length by default. It would be useful to be able to re-roll the stack to update the password in all of the scripts under this use-case.

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

When Jenkins is configured for another authentication provider (i.e. SAML), the existing admin login is invalidated. To work around this, an API token can be generated for the admin user. These tokens are 34 characters in length by default. It would be useful to be able to re-roll the stack to update the password in all of the scripts under this use-case.
