### PR TITLE
Allow Jenkins user to become root on agents

### DIFF
--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -1681,6 +1681,9 @@ Resources:
             'c_mkdir':
               command: 'mkdir /var/lib/jenkins && chown -R jenkins:jenkins /var/lib/jenkins'
               test: '[ ! -d /var/lib/jenkins ]'
+            'd_sudoers':
+              command: 'echo "jenkins ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jenkins'
+              test: '[ ! -f /etc/sudoers.d/jenkins ]'
           services:
             sysvinit:
               cfn-hup:


### PR DESCRIPTION
For environments where the builds require additional ad-hoc system packages to be installed (e.g. jq) and the builds aren't isolated to running inside their respective docker containers.

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

For environments where the builds require additional ad-hoc system packages to be installed (e.g. jq) and the builds aren't isolated to running inside their respective docker containers.