### PR TITLE
Fargate service with Cloud Map support

### DIFF
--- a/docs/fargate.md
+++ b/docs/fargate.md
@@ -34,9 +34,10 @@ This template describes a fault tolerant and scalable Fargate cluster on AWS.
 # Fargate service
 This template describes a fault tolerant and scalable Fargate service on AWS. The service scales based on CPU utilization.
 
-We provide two service templates:
+We provide three service templates:
 * `service-cluster-alb.yaml` uses the cluster's load balancer and path and/or host based routing.
 * `service-dedicated-alb.yaml` includes a dedicated load balancer (ALB).
+* `service-cloudmap.yaml` uses service discovery via Cloud Map instead a load balancer.
 
 ## Using the cluster's load balancer and path and/or host based routing
 This template describes a fault tolerant and scalable Fargate service that uses the cluster's load balancer and path and/or host based routing for incoming traffic.
@@ -83,3 +84,29 @@ This template describes a fault tolerant and scalable Fargate service that uses 
 * `vpc/zone-*.yaml`
 * `state/s3.yaml*`
 * `state/client-sg.yaml`
+
+
+## Using service discovery (aka. Cloud Map)
+This template describes a fault tolerant and scalable Fargate service that registers tasks at the service discovery registry (aka. Cloud Map). Allows inter-service communication without any load balancer in between.
+
+### Installation Guide
+1. This templates depends on one of our [`vpc-*azs.yaml`](./vpc/) templates. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/vpc/vpc-2azs.yaml&stackName=vpc)
+1. This templates depends on our `cluster.yaml` template. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/fargate/cluster.yaml&stackName=fargate-cluster&param_ParentVPCStack=vpc)
+1. This templates depends on our `vpc/cloudmap-private.yaml` template. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/vpc/cloudmap-private.yaml&stackName=cloudmap-private&param_ParentVPCStack=vpc)
+1. This templates depends on our `state/client-sg.yaml` template. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/state/client-sg.yaml&stackName=client&param_ParentVPCStack=vpc)
+1. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/fargate/service-dedicated-alb.yaml&stackName=fargate-service&param_ParentVPCStack=vpc&param_ParentClusterStack=fargate-cluster&param_ParentCloudMapStack=cloudmap-private&param_ParentClientStack=client)
+1. Click **Next** to proceed with the next step of the wizard.
+1. Specify a name and all parameters for the stack.
+1. Click **Next** to proceed with the next step of the wizard.
+1. Click **Next** to skip the **Options** step of the wizard.
+1. Check the **I acknowledge that this template might cause AWS CloudFormation to create IAM resources.** checkbox.
+1. Click **Create** to start the creation of the stack.
+1. Wait until the stack reaches the state **CREATE_COMPLETE**
+
+### Dependencies
+* `vpc/vpc-*azs.yaml` (**required**)
+* `fargate/cluster.yaml` (**required**)
+* `vpc/cloudmap-private.yaml` (**required**)
+* `state/client-sg.yaml` (**required**)
+* `operations/alert.yaml` (recommended)
+* `vpc/ssh-bastion.yaml`

--- a/docs/fargate.md
+++ b/docs/fargate.md
@@ -37,7 +37,7 @@ This template describes a fault tolerant and scalable Fargate service on AWS. Th
 We provide three service templates:
 * `service-cluster-alb.yaml` uses the cluster's load balancer and path and/or host based routing.
 * `service-dedicated-alb.yaml` includes a dedicated load balancer (ALB).
-* `service-cloudmap.yaml` uses service discovery via Cloud Map instead a load balancer.
+* `service-cloudmap.yaml` uses service discovery via Cloud Map instead of a load balancer.
 
 ## Using the cluster's load balancer and path and/or host based routing
 This template describes a fault tolerant and scalable Fargate service that uses the cluster's load balancer and path and/or host based routing for incoming traffic.

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -1,0 +1,661 @@
+---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# FIXME add to cfn-modules
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Fargate: service that runs on a Fargate cluster based on fargate/cluster.yaml with service discovery via Cloud Map, a cloudonaut.io template'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentVPCStack
+      - ParentClusterStack
+      - ParentAlertStack
+      - ParentCloudMapStack
+      - ParentClientStack
+      - ParentClientStack1
+      - ParentClientStack2
+      - ParentClientStack3
+    - Label:
+        default: 'Task Parameters'
+      Parameters:
+      - TaskPolicies
+      - AmbassadorImage
+      - AmbassadorCommand
+      - AmbassadorPort
+      - AmbassadorEnvironment1Key
+      - AmbassadorEnvironment1Value
+      - AmbassadorEnvironment2Key
+      - AmbassadorEnvironment2Value
+      - AmbassadorEnvironment3Key
+      - AmbassadorEnvironment3Value
+      - AppImage
+      - AppCommand
+      - AppPort
+      - AppEnvironment1Key
+      - AppEnvironment1Value
+      - AppEnvironment2Key
+      - AppEnvironment2Value
+      - AppEnvironment3Key
+      - AppEnvironment3Value
+      - SidecarImage
+      - SidecarCommand
+      - SidecarPort
+      - SidecarEnvironment1Key
+      - SidecarEnvironment1Value
+      - SidecarEnvironment2Key
+      - SidecarEnvironment2Value
+      - SidecarEnvironment3Key
+      - SidecarEnvironment3Value
+    - Label:
+        default: 'Service Parameters'
+      Parameters:
+      - Name
+      - Cpu
+      - Memory
+      - SubnetsReach
+      - AutoScaling
+      - DesiredCount
+      - MaxCapacity
+      - MinCapacity
+      - LogsRetentionInDays
+Parameters:
+  ParentVPCStack:
+    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Type: String
+  ParentClusterStack:
+    Description: 'Stack name of parent Cluster stack based on fargate/cluster.yaml template.'
+    Type: String
+  ParentAlertStack:
+    Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
+    Type: String
+    Default: ''
+  ParentCloudMapStack:
+    Description: 'Stack name of parent Cloud Map stack based on vpc/cloudmap-private.yaml template.'
+    Type: String
+  ParentClientStack:
+    Description: 'Stack name of parent client stack based on state/client-sg.yaml template.'
+    Type: String
+  ParentClientStack1:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentClientStack2:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentClientStack3:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  TaskPolicies:
+    Description: 'Comma-delimited list of IAM managed policy ARNs to attach to the task IAM role'
+    Type: String
+    Default: ''
+  AmbassadorImage:
+    Description: 'Optional Docker image to use for the ambassador container (https://docs.microsoft.com/en-us/azure/architecture/patterns/ambassador). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  AmbassadorCommand:
+    Description: 'Optional command used when starting the ambassador container.'
+    Type: String
+    Default: ''
+  AmbassadorPort:
+    Description: 'The port exposed by the ambassador container that receives traffic from the load balancer (AmbassadorPort <> AppPort <> SidecarPort; ignored if AmbassadorImage is not set).'
+    Type: Number
+    Default: 8000
+    MinValue: 1
+    MaxValue: 49150
+  AmbassadorEnvironment1Key:
+    Description: 'Optional environment variable 1 key for ambassador container.'
+    Type: String
+    Default: ''
+  AmbassadorEnvironment1Value:
+    Description: 'Optional environment variable 1 value for ambassador container.'
+    Type: String
+    Default: ''
+  AmbassadorEnvironment2Key:
+    Description: 'Optional environment variable 2 key for ambassador container.'
+    Type: String
+    Default: ''
+  AmbassadorEnvironment2Value:
+    Description: 'Optional environment variable 2 value for ambassador container.'
+    Type: String
+    Default: ''
+  AmbassadorEnvironment3Key:
+    Description: 'Optional environment variable 3 key for ambassador container.'
+    Type: String
+    Default: ''
+  AmbassadorEnvironment3Value:
+    Description: 'Optional environment variable 3 value for ambassador container.'
+    Type: String
+    Default: ''
+  AppImage:
+    Description: 'The Docker image to use for the app container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: 'widdix/hello:v1'
+  AppCommand:
+    Description: 'Optional commands (comma-delimited) used when starting the app container.'
+    Type: String
+    Default: ''
+  AppPort:
+    Description: 'The port exposed by the app container that receives traffic from the load balancer or the ambassador container (AppPort <> AmbassadorPort <> SidecarPort).'
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 49150
+  AppEnvironment1Key:
+    Description: 'Optional environment variable 1 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment1Value:
+    Description: 'Optional environment variable 1 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment2Key:
+    Description: 'Optional environment variable 2 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment2Value:
+    Description: 'Optional environment variable 2 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment3Key:
+    Description: 'Optional environment variable 3 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment3Value:
+    Description: 'Optional environment variable 3 value for app container.'
+    Type: String
+    Default: ''
+  SidecarImage:
+    Description: 'Optional Docker image to use for the sidecar container (https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  SidecarCommand:
+    Description: 'Optional command used when starting the sidecar container.'
+    Type: String
+    Default: ''
+  SidecarPort:
+    Description: 'The port exposed by the sidecar container reachable from the app container on host localhost (SidecarPort <> AmbassadorPort <> AppPort).'
+    Type: Number
+    Default: 9000
+    MinValue: 1
+    MaxValue: 49150
+  SidecarEnvironment1Key:
+    Description: 'Optional environment variable 1 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment1Value:
+    Description: 'Optional environment variable 1 value for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment2Key:
+    Description: 'Optional environment variable 2 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment2Value:
+    Description: 'Optional environment variable 2 value for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment3Key:
+    Description: 'Optional environment variable 3 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment3Value:
+    Description: 'Optional environment variable 3 value for sidecar container.'
+    Type: String
+    Default: ''
+  Name:
+    Description: 'The name of the service used for service discovery (Cloud Map).'
+    Type: String
+  Cpu:
+    Description: 'The minimum number of vCPUs to reserve for the container.'
+    Type: String
+    Default: '0.25'
+    AllowedValues: ['0.25', '0,5', '1', '2', '4']
+  Memory:
+    Description: 'The amount (in GB) of memory used by the task.'
+    Type: String
+    Default: '0.5'
+    AllowedValues: ['0.5', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30']
+  DesiredCount:
+    Description: 'The number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 2
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  MaxCapacity:
+    Description: 'The maximum number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 4
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  MinCapacity:
+    Description: 'The minimum number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 2
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  LogsRetentionInDays:
+    Description: 'Specifies the number of days you want to retain log events in the specified log group.'
+    Type: Number
+    Default: 14
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  SubnetsReach:
+    Description: 'Should the service have direct access to the Internet or do you prefer private subnets with NAT?'
+    Type: String
+    Default: Public
+    AllowedValues:
+    - Public
+    - Private
+  AutoScaling:
+    Description: 'Scale number of tasks based on CPU load?'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+Mappings:
+  CpuMap:
+    '0.25':
+      Cpu: 256
+    '0.5':
+      Cpu: 512
+    '1':
+      Cpu: 1024
+    '2':
+      Cpu: 2048
+    '4':
+      Cpu: 4096
+  MemoryMap:
+    '0.5':
+      Memory: 512
+    '1':
+      Memory: 1024
+    '2':
+      Memory: 2048
+    '3':
+      Memory: 3072
+    '4':
+      Memory: 4096
+    '5':
+      Memory: 5120
+    '6':
+      Memory: 6144
+    '7':
+      Memory: 7168
+    '8':
+      Memory: 8192
+    '9':
+      Memory: 9216
+    '10':
+      Memory: 10240
+    '11':
+      Memory: 11264
+    '12':
+      Memory: 12288
+    '13':
+      Memory: 13312
+    '14':
+      Memory: 14336
+    '15':
+      Memory: 15360
+    '16':
+      Memory: 16384
+    '17':
+      Memory: 17408
+    '18':
+      Memory: 18432
+    '19':
+      Memory: 19456
+    '20':
+      Memory: 20480
+    '21':
+      Memory: 21504
+    '22':
+      Memory: 22528
+    '23':
+      Memory: 23552
+    '24':
+      Memory: 24576
+    '25':
+      Memory: 25600
+    '26':
+      Memory: 26624
+    '27':
+      Memory: 27648
+    '28':
+      Memory: 28672
+    '29':
+      Memory: 29696
+    '30':
+      Memory: 30720
+Conditions:
+  HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
+  HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
+  HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
+  HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
+  HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
+  HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
+  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
+  HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
+  HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
+  HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
+  HasAmbassadorImage: !Not [!Equals [!Ref AmbassadorImage, '']]
+  HasAmbassadorCommand: !Not [!Equals [!Ref AmbassadorCommand, '']]
+  HasAmbassadorEnvironment1Key: !Not [!Equals [!Ref AmbassadorEnvironment1Key, '']]
+  HasAmbassadorEnvironment2Key: !Not [!Equals [!Ref AmbassadorEnvironment2Key, '']]
+  HasAmbassadorEnvironment3Key: !Not [!Equals [!Ref AmbassadorEnvironment3Key, '']]
+  HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
+  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
+  HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
+  HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
+  HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
+Resources:
+  ServiceDiscovery:
+    Type: 'AWS::ServiceDiscovery::Service'
+    Properties:
+      Description: !Ref 'AWS::StackName'
+      DnsConfig:
+        DnsRecords:
+        - Type: A
+          TTL: '30'
+        - Type: SRV
+          TTL: '30'
+        NamespaceId: {'Fn::ImportValue': !Sub '${ParentCloudMapStack}-NamespaceID'}
+        RoutingPolicy: MULTIVALUE
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: !Ref Name
+      NamespaceId: {'Fn::ImportValue': !Sub '${ParentCloudMapStack}-NamespaceID'}
+  TaskExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'ecs-tasks.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: AmazonECSTaskExecutionRolePolicy # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ecr:GetAuthorizationToken'
+            - 'ecr:BatchCheckLayerAvailability'
+            - 'ecr:GetDownloadUrlForLayer'
+            - 'ecr:BatchGetImage'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LogGroup.Arn'
+  TaskRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'ecs-tasks.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasTaskPolicies, !Split [',', !Ref TaskPolicies], !Ref 'AWS::NoValue']
+  TaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+      - !If
+        - HasAmbassadorImage
+        - Name: ambassador
+          Image: !Ref AmbassadorImage
+          Command: !If [HasAmbassadorCommand, !Ref AmbassadorCommand, !Ref 'AWS::NoValue']
+          PortMappings:
+          - ContainerPort: !Ref AmbassadorPort
+            Protocol: tcp
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              'awslogs-region': !Ref 'AWS::Region'
+              'awslogs-group': !Ref LogGroup
+              'awslogs-stream-prefix': ambassador
+          Environment:
+          - !If [HasAmbassadorEnvironment1Key, {Name: !Ref AmbassadorEnvironment1Key, Value: !Ref AmbassadorEnvironment1Value}, !Ref 'AWS::NoValue']
+          - !If [HasAmbassadorEnvironment2Key, {Name: !Ref AmbassadorEnvironment2Key, Value: !Ref AmbassadorEnvironment2Value}, !Ref 'AWS::NoValue']
+          - !If [HasAmbassadorEnvironment3Key, {Name: !Ref AmbassadorEnvironment3Key, Value: !Ref AmbassadorEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !Ref 'AWS::NoValue'
+      - Name: app
+        Image: !Ref AppImage
+        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
+        PortMappings:
+        - ContainerPort: !Ref AppPort
+          Protocol: tcp
+        Essential: true
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            'awslogs-region': !Ref 'AWS::Region'
+            'awslogs-group': !Ref LogGroup
+            'awslogs-stream-prefix': app
+        Environment:
+        Environment:
+        - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
+      - !If
+        - HasSidecarImage
+        - Name: sidecar
+          Image: !Ref SidecarImage
+          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
+          PortMappings:
+          - ContainerPort: !Ref SidecarPort
+            Protocol: tcp
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              'awslogs-region': !Ref 'AWS::Region'
+              'awslogs-group': !Ref LogGroup
+              'awslogs-stream-prefix': sidecar
+          Environment:
+          - !If [HasSidecarEnvironment1Key, {Name: !Ref SidecarEnvironment1Key, Value: !Ref SidecarEnvironment1Value}, !Ref 'AWS::NoValue']
+          - !If [HasSidecarEnvironment2Key, {Name: !Ref SidecarEnvironment2Key, Value: !Ref SidecarEnvironment2Value}, !Ref 'AWS::NoValue']
+          - !If [HasSidecarEnvironment3Key, {Name: !Ref SidecarEnvironment3Key, Value: !Ref SidecarEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !Ref 'AWS::NoValue'
+      Cpu: !FindInMap [CpuMap, !Ref Cpu, Cpu]
+      ExecutionRoleArn: !GetAtt 'TaskExecutionRole.Arn'
+      Family: !Ref 'AWS::StackName'
+      Memory: !FindInMap [MemoryMap, !Ref Memory, Memory]
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      TaskRoleArn: !GetAtt 'TaskRole.Arn'
+  LogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      RetentionInDays: !Ref LogsRetentionInDays
+  ServiceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Sub '${AWS::StackName}-service'
+      VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
+        ToPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
+        SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentClientStack}-ClientSecurityGroup'}
+  Service:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: !Ref DesiredCount
+      LaunchType: FARGATE
+      ServiceRegistries:
+      - ContainerName: !If [HasAmbassadorImage, ambassador, app]
+        ContainerPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
+        RegistryArn: !GetAtt 'ServiceDiscovery.Arn'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !If [HasSubnetsReachPublic, ENABLED, DISABLED]
+          SecurityGroups:
+          - !Ref ServiceSecurityGroup
+          - !If [HasClientSecurityGroup1, {'Fn::ImportValue': !Sub '${ParentClientStack1}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup2, {'Fn::ImportValue': !Sub '${ParentClientStack2}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup3, {'Fn::ImportValue': !Sub '${ParentClientStack3}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          Subnets: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-Subnets${SubnetsReach}'}]
+      TaskDefinition: !Ref TaskDefinition
+  CPUUtilizationTooHighAlarm:
+    Condition: HasAlertTopic
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Average CPU utilization over last 10 minutes higher than 80%'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 80
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+  ScalableTargetRole: # based on http://docs.aws.amazon.com/AmazonECS/latest/developerguide/autoscale_IAM_role.html
+    Condition: HasAutoScaling
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'application-autoscaling.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: AmazonEC2ContainerServiceAutoscaleRole
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ecs:DescribeServices'
+            - 'ecs:UpdateService'
+            Resource: '*'
+      - PolicyName: cloudwatch
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'cloudwatch:DescribeAlarms'
+            Resource: '*'
+  ScalableTarget:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    Properties:
+      MaxCapacity: !Ref MaxCapacity
+      MinCapacity: !Ref MinCapacity
+      ResourceId: !Sub
+      - 'service/${Cluster}/${Service}'
+      - Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+        Service: !GetAtt 'Service.Name'
+      RoleARN: !GetAtt 'ScalableTargetRole.Arn'
+      ScalableDimension: 'ecs:service:DesiredCount'
+      ServiceNamespace: ecs
+  ScaleUpPolicy:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: !Sub '${AWS::StackName}-scale-up'
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+        - MetricIntervalLowerBound: 0
+          ScalingAdjustment: 25
+  ScaleDownPolicy:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: !Sub '${AWS::StackName}-scale-down'
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+        - MetricIntervalUpperBound: 0
+          ScalingAdjustment: -25
+  CPUUtilizationHighAlarm:
+    Condition: HasAutoScaling
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Service is running out of CPU'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 60
+      AlarmActions:
+      - !Ref ScaleUpPolicy
+  CPUUtilizationLowAlarm:
+    Condition: HasAutoScaling
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Service is wasting CPU'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: LessThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 30
+      AlarmActions:
+      - !Ref ScaleDownPolicy
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'fargate/service-cloudmap'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -29,6 +29,7 @@ Metadata:
       - ParentClientStack1
       - ParentClientStack2
       - ParentClientStack3
+      - ParentSSHBastionStack
     - Label:
         default: 'Task Parameters'
       Parameters:
@@ -99,6 +100,10 @@ Parameters:
     Default: ''
   ParentClientStack3:
     Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentSSHBastionStack:
+    Description: 'Optional but recommended stack name of parent SSH bastion host/instance stack based on vpc/vpc-*-bastion.yaml template.'
     Type: String
     Default: ''
   TaskPolicies:
@@ -349,6 +354,7 @@ Conditions:
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
+  HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
   HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
   HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
   HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
@@ -498,6 +504,15 @@ Resources:
         FromPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
         ToPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
         SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentClientStack}-ClientSecurityGroup'}
+  ServiceSecurityGroupInSSHBastion:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref ServiceSecurityGroup
+      IpProtocol: tcp
+      FromPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
+      ToPort: !If [HasAmbassadorImage, !Ref AmbassadorPort, !Ref AppPort]
+      SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentSSHBastionStack}-SecurityGroup'}
   Service:
     Type: 'AWS::ECS::Service'
     Properties:

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -454,7 +454,6 @@ Resources:
             'awslogs-group': !Ref LogGroup
             'awslogs-stream-prefix': app
         Environment:
-        Environment:
         - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
         - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
         - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']

--- a/fargate/service-cluster-alb.yaml
+++ b/fargate/service-cluster-alb.yaml
@@ -41,6 +41,7 @@ Metadata:
       Parameters:
       - TaskPolicies
       - AmbassadorImage
+      - AmbassadorCommand
       - AmbassadorPort
       - AmbassadorEnvironment1Key
       - AmbassadorEnvironment1Value
@@ -49,6 +50,7 @@ Metadata:
       - AmbassadorEnvironment3Key
       - AmbassadorEnvironment3Value
       - AppImage
+      - AppCommand
       - AppPort
       - AppEnvironment1Key
       - AppEnvironment1Value
@@ -57,6 +59,7 @@ Metadata:
       - AppEnvironment3Key
       - AppEnvironment3Value
       - SidecarImage
+      - SidecarCommand
       - SidecarPort
       - SidecarEnvironment1Key
       - SidecarEnvironment1Value
@@ -145,6 +148,10 @@ Parameters:
     Description: 'Optional Docker image to use for the ambassador container (https://docs.microsoft.com/en-us/azure/architecture/patterns/ambassador). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
     Default: ''
+  AmbassadorCommand:
+    Description: 'Optional command used when starting the ambassador container.'
+    Type: String
+    Default: ''
   AmbassadorPort:
     Description: 'The port exposed by the ambassador container that receives traffic from the load balancer (AmbassadorPort <> AppPort <> SidecarPort; ignored if AmbassadorImage is not set).'
     Type: Number
@@ -179,6 +186,10 @@ Parameters:
     Description: 'The Docker image to use for the app container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
     Default: 'widdix/hello:v1'
+  AppCommand:
+    Description: 'Optional commands (comma-delimited) used when starting the app container.'
+    Type: String
+    Default: ''
   AppPort:
     Description: 'The port exposed by the app container that receives traffic from the load balancer or the ambassador container (AppPort <> AmbassadorPort <> SidecarPort).'
     Type: Number
@@ -211,6 +222,10 @@ Parameters:
     Default: ''
   SidecarImage:
     Description: 'Optional Docker image to use for the sidecar container (https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  SidecarCommand:
+    Description: 'Optional command used when starting the sidecar container.'
     Type: String
     Default: ''
   SidecarPort:
@@ -385,14 +400,17 @@ Conditions:
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
   HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
+  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
   HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
   HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
   HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
   HasAmbassadorImage: !Not [!Equals [!Ref AmbassadorImage, '']]
+  HasAmbassadorCommand: !Not [!Equals [!Ref AmbassadorCommand, '']]
   HasAmbassadorEnvironment1Key: !Not [!Equals [!Ref AmbassadorEnvironment1Key, '']]
   HasAmbassadorEnvironment2Key: !Not [!Equals [!Ref AmbassadorEnvironment2Key, '']]
   HasAmbassadorEnvironment3Key: !Not [!Equals [!Ref AmbassadorEnvironment3Key, '']]
   HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
+  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
   HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
   HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
   HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
@@ -536,6 +554,7 @@ Resources:
         - HasAmbassadorImage
         - Name: ambassador
           Image: !Ref AmbassadorImage
+          Command: !If [HasAmbassadorCommand, !Ref AmbassadorCommand, !Ref 'AWS::NoValue']
           PortMappings:
           - ContainerPort: !Ref AmbassadorPort
             Protocol: tcp
@@ -553,6 +572,7 @@ Resources:
         - !Ref 'AWS::NoValue'
       - Name: app
         Image: !Ref AppImage
+        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
         PortMappings:
         - ContainerPort: !Ref AppPort
           Protocol: tcp
@@ -571,6 +591,7 @@ Resources:
         - HasSidecarImage
         - Name: sidecar
           Image: !Ref SidecarImage
+          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
           PortMappings:
           - ContainerPort: !Ref SidecarPort
             Protocol: tcp

--- a/fargate/service-dedicated-alb.yaml
+++ b/fargate/service-dedicated-alb.yaml
@@ -42,6 +42,7 @@ Metadata:
       Parameters:
       - TaskPolicies
       - AmbassadorImage
+      - AmbassadorCommand
       - AmbassadorPort
       - AmbassadorEnvironment1Key
       - AmbassadorEnvironment1Value
@@ -50,6 +51,7 @@ Metadata:
       - AmbassadorEnvironment3Key
       - AmbassadorEnvironment3Value
       - AppImage
+      - AppCommand
       - AppPort
       - AppEnvironment1Key
       - AppEnvironment1Value
@@ -58,6 +60,7 @@ Metadata:
       - AppEnvironment3Key
       - AppEnvironment3Value
       - SidecarImage
+      - SidecarCommand
       - SidecarPort
       - SidecarEnvironment1Key
       - SidecarEnvironment1Value
@@ -145,6 +148,10 @@ Parameters:
     Description: 'Optional Docker image to use for the ambassador container (https://docs.microsoft.com/en-us/azure/architecture/patterns/ambassador). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
     Default: ''
+  AmbassadorCommand:
+    Description: 'Optional command used when starting the ambassador container.'
+    Type: String
+    Default: ''
   AmbassadorPort:
     Description: 'The port exposed by the ambassador container that receives traffic from the load balancer (AmbassadorPort <> AppPort <> SidecarPort; ignored if AmbassadorImage is not set).'
     Type: Number
@@ -179,6 +186,10 @@ Parameters:
     Description: 'The Docker image to use for the app container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
     Default: 'widdix/hello:v1'
+  AppCommand:
+    Description: 'Optional commands (comma-delimited) used when starting the app container.'
+    Type: String
+    Default: ''
   AppPort:
     Description: 'The port exposed by the app container that receives traffic from the load balancer or the ambassador container (AppPort <> AmbassadorPort <> SidecarPort).'
     Type: Number
@@ -211,6 +222,10 @@ Parameters:
     Default: ''
   SidecarImage:
     Description: 'Optional Docker image to use for the sidecar container (https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  SidecarCommand:
+    Description: 'Optional command used when starting the sidecar container.'
     Type: String
     Default: ''
   SidecarPort:
@@ -389,14 +404,17 @@ Conditions:
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
   HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
+  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
   HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
   HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
   HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
   HasAmbassadorImage: !Not [!Equals [!Ref AmbassadorImage, '']]
+  HasAmbassadorCommand: !Not [!Equals [!Ref AmbassadorCommand, '']]
   HasAmbassadorEnvironment1Key: !Not [!Equals [!Ref AmbassadorEnvironment1Key, '']]
   HasAmbassadorEnvironment2Key: !Not [!Equals [!Ref AmbassadorEnvironment2Key, '']]
   HasAmbassadorEnvironment3Key: !Not [!Equals [!Ref AmbassadorEnvironment3Key, '']]
   HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
+  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
   HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
   HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
   HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
@@ -636,6 +654,7 @@ Resources:
         - HasAmbassadorImage
         - Name: ambassador
           Image: !Ref AmbassadorImage
+          Command: !If [HasAmbassadorCommand, !Ref AmbassadorCommand, !Ref 'AWS::NoValue']
           PortMappings:
           - ContainerPort: !Ref AmbassadorPort
             Protocol: tcp
@@ -653,6 +672,7 @@ Resources:
         - !Ref 'AWS::NoValue'
       - Name: app
         Image: !Ref AppImage
+        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
         PortMappings:
         - ContainerPort: !Ref AppPort
           Protocol: tcp
@@ -671,6 +691,7 @@ Resources:
         - HasSidecarImage
         - Name: sidecar
           Image: !Ref SidecarImage
+          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
           PortMappings:
           - ContainerPort: !Ref SidecarPort
             Protocol: tcp

--- a/test/src/test/java/de/widdix/awscftemplates/ATest.java
+++ b/test/src/test/java/de/widdix/awscftemplates/ATest.java
@@ -6,6 +6,7 @@ import com.evanlennick.retry4j.CallResults;
 import com.evanlennick.retry4j.RetryConfig;
 import com.evanlennick.retry4j.RetryConfigBuilder;
 import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import org.junit.Assert;
 
@@ -38,6 +39,7 @@ public abstract class ATest {
         public final String userName;
         public final byte[] sshPrivateKeyBlob;
         public final String sshPublicKeyId;
+
         public User(final String userName, final byte[] sshPrivateKeyBlob, final String sshPublicKeyId) {
             super();
             this.userName = userName;
@@ -70,6 +72,16 @@ public abstract class ATest {
             return true;
         };
         Assert.assertTrue(this.retry(callable));
+    }
+
+    protected final Session tunnelSSH(final String host, final KeyPair key, final Integer localPort, final String remoteHost, final Integer remotePort) throws JSchException {
+        final JSch jsch = new JSch();
+        final Session session = jsch.getSession("ec2-user", host);
+        jsch.addIdentity(key.getKeyName(), key.getKeyMaterial().getBytes(), null, null);
+        jsch.setConfig("StrictHostKeyChecking", "no"); // for testing this should be fine. adding the host key seems to be only possible via a file which is not very useful here
+        session.setPortForwardingL(localPort, remoteHost, remotePort);
+        session.connect(10000);
+        return session;
     }
 
 }

--- a/vpc/cloudmap-private.yaml
+++ b/vpc/cloudmap-private.yaml
@@ -1,0 +1,62 @@
+---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# FIXME add to cfn-modules
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'VPC: a private service registry (aka. Cloud Map private namespace), a cloudonaut.io template'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentVPCStack
+    - Label:
+        default: 'Namespace Parameters'
+      Parameters:
+      - Name
+Parameters:
+  ParentVPCStack:
+    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Type: String
+  Name:
+    Description: 'The name of the namespace.'
+    Type: String
+Resources:
+  Namespace:
+    Type: 'AWS::ServiceDiscovery::PrivateDnsNamespace'
+    Properties:
+      Description: !Ref 'AWS::StackName'
+      Vpc: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
+      Name: !Ref Name
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'vpc/cloudmap-private'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+  NamespaceARN:
+    Description: 'The ARN of the namespace.'
+    Value: !GetAtt 'Namespace.Arn'
+    Export:
+      Name: !Sub '${AWS::StackName}-NamespaceARN'
+  NamespaceID:
+    Description: 'The ID of the namespace.'
+    Value: !GetAtt 'Namespace.Id'
+    Export:
+      Name: !Sub '${AWS::StackName}-NamespaceID'


### PR DESCRIPTION
Adding service discovery aka. Cloud Map to the Fargate templates.

- [x] Add template `fargate/service-cloudmap` including a service registering tasks at service discovery.
- [x] Extend `fargate/service-cluster-alb` and `fargate/service-dedicated-alb` with parameter `AmbassadorCommand`.
- [x] Implement tests.
- [x] Extend documentation.