### PR TITLE
Redis: set default for AuthToken

### DIFF
--- a/state/elasticache-redis.yaml
+++ b/state/elasticache-redis.yaml
@@ -96,8 +96,9 @@ Parameters:
     - 'true'
     - 'false'
   AuthToken:
-    Description: 'Password (16 to 128 characters) used to authenticate against Redis. Requried when TransitEncryption = true. Keep empty to disable password-protection.'
+    Description: 'Password (16 to 128 characters) used to authenticate against Redis. Requried when TransitEncryption = true. Leave blank to disable password-protection.'
     Type: 'String'
+    Default: ''
     MaxLength: 128
   SubDomainName:
     Description: 'Name that is used to create the DNS entry §{SubDomainName}.§{HostedZoneName} (required when ParentZoneStack is set, otherwise not considered)'

--- a/test/src/test/java/de/widdix/awscftemplates/state/TestElastiCacheRedis.java
+++ b/test/src/test/java/de/widdix/awscftemplates/state/TestElastiCacheRedis.java
@@ -22,8 +22,7 @@ public class TestElastiCacheRedis extends ACloudFormationTest {
                     this.createStack(stackName,
                             "state/elasticache-redis.yaml",
                             new Parameter().withParameterKey("ParentVPCStack").withParameterValue(vpcStackName),
-                            new Parameter().withParameterKey("ParentClientStack").withParameterValue(clientStackName),
-                            new Parameter().withParameterKey("AuthToken").withParameterValue("")
+                            new Parameter().withParameterKey("ParentClientStack").withParameterValue(clientStackName)
                     );
                     // TODO how can we check if this stack works? start a bastion host and try to connect?
                 } finally {


### PR DESCRIPTION
Simplifying the default for ElastiCache Redis. See https://github.com/widdix/aws-cf-templates/issues/263 for more details.
