### PR TITLE
ECS: Auto Scaling Lifecycle Hook for Instance Draining based on Lambda

### DIFF
--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -161,10 +161,10 @@ Parameters:
   DrainingTimeoutInSeconds:
     Description: 'Maximum time in seconds an EC2 instance waits when terminating until all containers are moved to another EC2 instance (draining).'
     Type: Number
-    Default: 60
-    ConstraintDescription: 'Must be in the range [60-7200]'
+    Default: 600 # 10 minutes
+    ConstraintDescription: 'Must be in the range [60-86400]'
     MinValue: 60
-    MaxValue: 7200
+    MaxValue: 86400 # 24 hours
   ContainerMaxCPU:
     Description: 'The maximum number of cpu reservation per container that you plan to run on this cluster. A container instance has 1,024 CPU units for every CPU core.'
     Type: Number
@@ -790,165 +790,6 @@ Resources:
                 path=Resources.LaunchConfiguration.Metadata.AWS::CloudFormation::Init
                 action=/opt/aws/bin/cfn-init --verbose --stack=${AWS::StackName} --region=${AWS::Region} --resource=LaunchConfiguration
                 runas=root
-            '/etc/init.d/lifecycle-poller':
-              content: |
-                #!/usr/bin/env ruby
-                # chkconfig:    - 80 20
-                APP_NAME = 'lifecycle-poller'
-                APP_PATH = '/opt/lifecycle-poller/daemon.rb'
-                case ARGV.first
-                  when 'start'
-                    puts "Starting #{APP_NAME}..."
-                    system(APP_PATH, 'start')
-                    exit($?.exitstatus)
-                  when 'stop'
-                    system(APP_PATH, 'stop')
-                    exit($?.exitstatus)
-                  when 'restart'
-                    system(APP_PATH, 'restart')
-                    exit($?.exitstatus)
-                  when 'status'
-                    system(APP_PATH, 'status')
-                    exit($?.exitstatus)
-                end
-                unless %w{start stop restart status}.include? ARGV.first
-                  puts "Usage: #{APP_NAME} {start|stop|restart|status}"
-                  exit(1)
-                end
-              mode: '000755'
-              owner: root
-              group: root
-            '/opt/lifecycle-poller/poller.conf':
-              content: !Sub |
-                region: ${AWS::Region}
-                cluster: ${Cluster}
-                queueUrl: ${AutoScalingGroupLifecycleHookQueue}
-                maxWaitInSeconds: ${DrainingTimeoutInSeconds}
-              mode: '000400'
-              owner: root
-              group: root
-            '/opt/lifecycle-poller/daemon.rb':
-              content: |
-                #!/usr/bin/env ruby
-                require 'daemons'
-                Daemons.run(__dir__ + '/worker.rb', {:monitor => true, :log_output_syslog => true})
-              mode: '000500'
-              owner: root
-              group: root
-            '/opt/lifecycle-poller/worker.rb':
-              content: |
-                #!/usr/bin/env ruby
-                require 'net/http'
-                require 'aws-sdk-ecs'
-                require 'aws-sdk-autoscaling'
-                require 'aws-sdk-sqs'
-                require 'json'
-                require 'uri'
-                require 'yaml'
-                require 'syslog/logger'
-                $log = Syslog::Logger.new 'poller'
-                $conf = YAML::load_file(__dir__ + '/poller.conf')
-                Aws.config.update(region: $conf['region'])
-                $log.info 'poller started'
-                def fetchContainerInstanceId(ec2InstanceId)
-                  ecs = Aws::ECS::Client.new()
-                  resp1 = ecs.list_container_instances({
-                    cluster: $conf['cluster']
-                  })
-                  resp2 = ecs.describe_container_instances({
-                    cluster: $conf['cluster'],
-                    container_instances: resp1.container_instance_arns,
-                  })
-                  cis = resp2.container_instances.select {|ci| ci.ec2_instance_id == ec2InstanceId}
-                  if cis.first().nil?
-                    return nil
-                  else
-                    return cis.first().container_instance_arn.split("/").last()
-                  end
-                end
-                def drainContainerInstanceId(containerInstanceId)
-                  ecs = Aws::ECS::Client.new()
-                  ecs.update_container_instances_state({
-                    cluster: $conf['cluster'],
-                    container_instances: [containerInstanceId],
-                    status: "DRAINING"
-                  })
-                end
-                def isContainerInstanceIdle(containerInstanceId)
-                  ecs = Aws::ECS::Client.new()
-                  resp = ecs.list_tasks({
-                    cluster: $conf['cluster'],
-                    container_instance: containerInstanceId
-                  })
-                  return resp.task_arns.empty?
-                end
-                def awaitContainerInstanceIdle(poller, message, containerInstanceId)
-                  endTime = Time.now.to_i + $conf['maxWaitInSeconds']
-                  while Time.now.to_i < endTime do
-                    if isContainerInstanceIdle containerInstanceId
-                      $log.info "container instance #{containerInstanceId} is idle"
-                      return true
-                    end
-                    poller.change_message_visibility_timeout(message, 30)
-                    sleep 15 # seconds
-                  end
-                  $log.error "container instance #{containerInstanceId} is not idle, but wait time elapsed"
-                  return false
-                end
-                def completeLifecycleAction(token, hook, asg)
-                  begin
-                    autoscaling = Aws::AutoScaling::Client.new()
-                    autoscaling.complete_lifecycle_action(
-                      lifecycle_hook_name: hook,
-                      auto_scaling_group_name: asg,
-                      lifecycle_action_token: token,
-                      lifecycle_action_result: 'CONTINUE'
-                    )
-                    $log.info "Lifecycle action completed"
-                    return true
-                  rescue Exception => e
-                    if e.code == 'ValidationError'
-                      $log.info "Lifecycle action failed validation: #{e.inspect}"
-                      return true
-                    else
-                      raise e
-                    end
-                  end
-                end
-                def pollSQS()
-                  poller = Aws::SQS::QueuePoller.new($conf['queueUrl'])
-                  poller.poll do |msg|
-                    begin
-                      body = JSON.parse(msg.body)
-                      $log.debug "message #{body}"
-                      if body['Event'] == 'autoscaling:TEST_NOTIFICATION'
-                        $log.info 'received test notification'
-                      else
-                        if body['LifecycleTransition'] == 'autoscaling:EC2_INSTANCE_TERMINATING'
-                          $log.info "lifecycle transition for EC2 instance #{body['EC2InstanceId']}"
-                          containerInstanceId = fetchContainerInstanceId body['EC2InstanceId']
-                          if containerInstanceId.nil?
-                            $log.info "no container instance found for EC2 instance #{body['EC2InstanceId']}"
-                          else
-                            $log.info "lifecycle transition for container instance #{containerInstanceId}"
-                            drainContainerInstanceId containerInstanceId
-                            awaitContainerInstanceIdle poller, msg, containerInstanceId
-                          end
-                          completeLifecycleAction body['LifecycleActionToken'], body['LifecycleHookName'], body['AutoScalingGroupName']
-                        else
-                          $log.error "received unsupported lifecycle transition: #{body['LifecycleTransition']}"
-                        end
-                      end
-                    rescue Exception => e
-                      $log.error "message failed: #{e.inspect} #{msg.inspect}"
-                      raise e
-                    end
-                  end
-                end
-                pollSQS
-              mode: '000500'
-              owner: root
-              group: root
           services:
             sysvinit:
               cfn-hup:
@@ -963,14 +804,6 @@ Resources:
                 packages:
                   yum:
                   - amazon-ssm-agent
-              lifecycle-poller:
-                enabled: true
-                ensureRunning: true
-                files:
-                - '/etc/init.d/lifecycle-poller'
-                - '/opt/lifecycle-poller/poller.conf'
-                - '/opt/lifecycle-poller/daemon.rb'
-                - '/opt/lifecycle-poller/worker.rb'
     Properties:
       ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', ECSAMI]
       IamInstanceProfile: !Ref InstanceProfile
@@ -1045,7 +878,7 @@ Resources:
     Type: 'AWS::SQS::Queue'
     Properties:
       QueueName: !Sub '${AWS::StackName}-lifecycle-hook'
-      VisibilityTimeout: 30
+      VisibilityTimeout: 60
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt 'AutoScalingGroupLifecycleHookDeadLetterQueue.Arn'
         maxReceiveCount: 5
@@ -1114,7 +947,7 @@ Resources:
   AutoScalingGroupTerminatingLifecycleHook:
     Type: 'AWS::AutoScaling::LifecycleHook'
     Properties:
-      HeartbeatTimeout: !Ref DrainingTimeoutInSeconds
+      HeartbeatTimeout: 600
       DefaultResult: CONTINUE
       AutoScalingGroupName: !Ref AutoScalingGroup
       LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING'
@@ -1449,6 +1282,97 @@ Resources:
       Dimensions:
       - Name: FunctionName
         Value: !Ref SchedulableContainersLambdaV2
+  DrainInstanceLambdaRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'lambda.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: # TODO get rid of managed policy
+      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+      - PolicyName: draininstance
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'sqs:DeleteMessage'
+            - 'sqs:ReceiveMessage'
+            - 'sqs:SendMessage'
+            - 'sqs:GetQueueAttributes'
+            Resource: !GetAtt 'AutoScalingGroupLifecycleHookQueue.Arn'
+          - Effect: Allow
+            Action:
+            - 'ecs:ListContainerInstances'
+            Resource: !GetAtt 'Cluster.Arn'
+          - Effect: Allow
+            Action:
+            - 'ecs:updateContainerInstancesState'
+            - 'ecs:listTasks'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'ecs:cluster': !GetAtt 'Cluster.Arn'
+          - Effect: Allow
+            Action:
+            - 'autoscaling:CompleteLifecycleAction'
+            - 'autoscaling:RecordLifecycleActionHeartbeat'
+            Resource: !Sub 'arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AutoScalingGroup}'
+  DrainInstanceEventSourceMapping:
+    Type: 'AWS::Lambda::EventSourceMapping'
+    Properties:
+      BatchSize: 1
+      Enabled: true
+      EventSourceArn: !GetAtt 'AutoScalingGroupLifecycleHookQueue.Arn'
+      FunctionName: !GetAtt DrainInstanceLambda.Arn
+  DrainInstanceLambda:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code:
+        ZipFile: |
+          const lib = require('/opt/lib.js');
+          exports.handler = async function(event, context) {
+            return await lib.handler(event, context);
+          };
+      Layers:
+      - !Sub 'arn:aws:lambda:${AWS::Region}:820394158530:layer:aws-cf-templates-lambda-drain-instance:2'
+      Handler: 'index.handler'
+      MemorySize: 128
+      Role: !GetAtt 'DrainInstanceLambdaRole.Arn'
+      Runtime: 'nodejs8.10'
+      Timeout: 30
+      Environment:
+        Variables:
+          CLUSTER: !Ref Cluster
+          QUEUE_URL: !Ref AutoScalingGroupLifecycleHookQueue
+          DRAINING_TIMEOUT: !Ref DrainingTimeoutInSeconds
+      ReservedConcurrentExecutions: 1
+  DrainInstanceLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${DrainInstanceLambda}'
+      RetentionInDays: !Ref LogsRetentionInDays
+  DrainInstanceLambdaErrorsTooHighAlarm:
+    Condition: HasAlertTopic
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Invocations failed due to errors in the function'
+      Namespace: 'AWS/Lambda'
+      MetricName: Errors
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+      Dimensions:
+      - Name: FunctionName
+        Value: !Ref DrainInstanceLambda
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/ecs/lambda-drain-instance/README.md
+++ b/ecs/lambda-drain-instance/README.md
@@ -1,0 +1,5 @@
+# Lambda: Drain Instance
+
+## Deploy
+
+Use the `deploy.sh` script to deploy the Lambda layer including the code and libraries to all regions. Update the layer ARN within the `cluster.yaml` template afterwards.

--- a/ecs/lambda-drain-instance/deploy.sh
+++ b/ecs/lambda-drain-instance/deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -ex
+
+npm ci
+mkdir nodejs
+mv node_modules/ nodejs/
+zip -r layer.zip nodejs/ lib.js
+
+# publish (region)
+publish () {
+  echo "publish ${1}"
+  version=$(aws lambda publish-layer-version --layer-name aws-cf-templates-lambda-drain-instance --zip-file fileb://layer.zip --query Version --output text --region ${1})
+  aws lambda add-layer-version-permission --layer-name aws-cf-templates-lambda-drain-instance --version-number ${version} --statement-id "aws-cf-templates" --action "lambda:GetLayerVersion" --principal "*" --region ${1}
+}
+
+publish ap-northeast-1
+publish ap-northeast-2
+publish ap-south-1
+publish ap-southeast-1
+publish ap-southeast-2
+publish ca-central-1
+publish eu-central-1
+publish eu-north-1
+publish eu-west-1
+publish eu-west-2
+publish eu-west-3
+publish sa-east-1
+publish us-east-1
+publish us-east-2
+publish us-west-1
+publish us-west-2
+
+rm layer.zip
+rm -fR nodejs

--- a/ecs/lambda-drain-instance/lib.js
+++ b/ecs/lambda-drain-instance/lib.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// see README.md for deployment instructions
+
+const AWS = require('aws-sdk');
+const ecs = new AWS.ECS({apiVersion: '2014-11-13'});
+const sqs = new AWS.SQS({apiVersion: '2012-11-05'});
+const asg = new AWS.AutoScaling({apiVersion: '2011-01-01'});
+
+const cluster = process.env.CLUSTER;
+const queueUrl = process.env.QUEUE_URL;
+const drainingTimeout = process.env.DRAINING_TIMEOUT;
+
+async function getContainerInstanceArn(ec2InstanceId) {
+  console.log(`getContainerInstanceArn(${ec2InstanceId})`);
+  const listResult = await ecs.listContainerInstances({cluster: cluster, filter: `ec2InstanceId == '${ec2InstanceId}'`}).promise();
+  return listResult.containerInstanceArns[0];
+}
+
+async function drainInstance(containerInstanceArn) {
+  console.log(`drainInstance(${containerInstanceArn})`);
+  await ecs.updateContainerInstancesState({cluster: cluster, containerInstances: [containerInstanceArn], status: 'DRAINING'}).promise();
+}
+
+async function wait(containerInstanceArn, autoScalingGroupName, lifecycleHookName, lifecycleActionToken, terminateTime) {
+  console.log(`wait(${containerInstanceArn}, ${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken}, ${terminateTime})`);
+  let payload = {
+    Service: 'DrainInstance',
+    Event: 'custom:DRAIN_WAIT',
+    ContainerInstanceArn: containerInstanceArn,
+    AutoScalingGroupName: autoScalingGroupName,
+    LifecycleHookName: lifecycleHookName,
+    LifecycleActionToken: lifecycleActionToken,
+    TerminateTime: terminateTime
+  }
+  await sqs.sendMessage({
+      QueueUrl: queueUrl,
+      DelaySeconds: 60,
+      MessageBody: JSON.stringify(payload)
+    }).promise();
+}
+
+async function deleteMessage(receiptHandle) {
+  console.log(`deleteMessage(${receiptHandle})`);
+  await sqs.deleteMessage({
+      QueueUrl: queueUrl,
+      ReceiptHandle: receiptHandle
+    }).promise();
+}
+
+async function countTasks(containerInstanceArn) {
+  console.log(`countTasks(${containerInstanceArn})`);
+  const listResult = await ecs.listTasks({cluster: cluster, containerInstance: containerInstanceArn}).promise();
+  return listResult.taskArns.length;
+}
+
+async function terminateInstance(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
+  console.log(`terminateInstance(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
+  asg.completeLifecycleAction({
+      AutoScalingGroupName: autoScalingGroupName, 
+      LifecycleHookName: lifecycleHookName,
+      LifecycleActionToken: lifecycleActionToken,
+      LifecycleActionResult: 'CONTINUE'
+    }).promise();
+}
+
+async function hearbeat(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
+  console.log(`hearbeat(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
+  asg.recordLifecycleActionHeartbeat({
+      AutoScalingGroupName: autoScalingGroupName, 
+      LifecycleHookName: lifecycleHookName,
+      LifecycleActionToken: lifecycleActionToken
+    }).promise();
+}
+
+exports.handler = async function(event, context) {
+  console.log(`Invoke: ${JSON.stringify(event)}`);
+
+  const body = JSON.parse(event.Records[0].body); // batch size is 1
+  const receiptHandle = event.Records[0].receiptHandle;
+
+  if (body.Service === 'AWS Auto Scaling' && body.Event === 'autoscaling:TEST_NOTIFICATION') {
+    console.log('Ingoring autoscaling:TEST_NOTIFICATION')
+  } else if (body.Service === 'AWS Auto Scaling' && body.LifecycleTransition === 'autoscaling:EC2_INSTANCE_TERMINATING') {
+    let lifecycleActionToken = body.LifecycleActionToken;
+    let containerInstanceArn = await getContainerInstanceArn(body.EC2InstanceId);
+    await drainInstance(containerInstanceArn);
+    await wait(containerInstanceArn, body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken, body.Time);
+  } else if (body.Service === 'DrainInstance' && body.Event === 'custom:DRAIN_WAIT') {
+    let taskCount = await countTasks(body.ContainerInstanceArn);
+    if (taskCount === 0) {
+      await terminateInstance(body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken);
+    } else {
+      let actionDuration = Math.abs(new Date(body.TerminateTime).getTime() - new Date().getTime()) / 1000;
+      if (actionDuration < drainingTimeout) {
+        await hearbeat(body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken);
+        await wait(body.ContainerInstanceArn, body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken, body.TerminateTime);
+      } else {
+        console.log('Timeout for instance termination reached.');
+        await terminateInstance(body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken);
+      }
+    }
+  } else {
+    console.log('Ignoring invalid event ...');
+  }
+  await deleteMessage(receiptHandle);
+};

--- a/ecs/lambda-drain-instance/package-lock.json
+++ b/ecs/lambda-drain-instance/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "aws-cf-templates-drain-instance",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.427.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.427.0.tgz",
+      "integrity": "sha512-NpFNZa7Wt9fQ8hRLt40OD1ii3qnIhUkpXH4fMSjXP2YqGxCYAHYRj2yARN86YJKCMH566+QobTRyPjtgEWmMKA==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/ecs/lambda-drain-instance/package.json
+++ b/ecs/lambda-drain-instance/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aws-cf-templates-drain-instance",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "aws-sdk": "2.427.0"
+  }
+}


### PR DESCRIPTION
Rewrite of the Auto Scaling Lifecycle Hook. Use Lambda instead of script running on EC2. Support instance draining timeouts up to 24 hours.