### PR TITLE
ECS: change Lambda log statements for easier debugging

### DIFF
--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1335,9 +1335,7 @@ Resources:
       Code:
         ZipFile: |
           const lib = require('/opt/lib.js');
-          exports.handler = async function(event, context) {
-            return await lib.handler(event, context);
-          };
+          exports.handler = (event, context) => lib.handler(event, context);
       Layers:
       - !Sub 'arn:aws:lambda:${AWS::Region}:820394158530:layer:aws-cf-templates-lambda-drain-instance:2'
       Handler: 'index.handler'

--- a/ecs/lambda-drain-instance/deploy.sh
+++ b/ecs/lambda-drain-instance/deploy.sh
@@ -1,9 +1,25 @@
 #!/bin/bash -ex
 
-npm ci
-mkdir nodejs
-mv node_modules/ nodejs/
-zip -r layer.zip nodejs/ lib.js
+TEMP_PATH=.temp
+RELEASE_ZIP=layer.zip
+
+# Copy sources to temporary folder
+rm -r "$TEMP_PATH" 2>/dev/null || true
+mkdir -p "$TEMP_PATH"
+cp -R *.js *.json "$TEMP_PATH/"
+cd "$TEMP_PATH"
+
+# Remove aws-sdk, already installed on Lambda
+npm uninstall aws-sdk
+# Install dependencies
+npm ci --production
+# Package artifact
+rm "../$RELEASE_ZIP" 2>/dev/null || true
+zip -r "../$RELEASE_ZIP" .
+
+# Cleanup
+cd ..
+rm -r "$TEMP_PATH"
 
 # publish (region)
 publish () {
@@ -30,4 +46,3 @@ publish us-west-1
 publish us-west-2
 
 rm layer.zip
-rm -fR nodejs

--- a/ecs/lambda-drain-instance/lib.js
+++ b/ecs/lambda-drain-instance/lib.js
@@ -56,7 +56,7 @@ async function countTasks(containerInstanceArn) {
 
 async function terminateInstance(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
   console.log(`terminateInstance(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
-  asg.completeLifecycleAction({
+  await asg.completeLifecycleAction({
       AutoScalingGroupName: autoScalingGroupName, 
       LifecycleHookName: lifecycleHookName,
       LifecycleActionToken: lifecycleActionToken,
@@ -66,7 +66,7 @@ async function terminateInstance(autoScalingGroupName, lifecycleHookName, lifecy
 
 async function hearbeat(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
   console.log(`hearbeat(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
-  asg.recordLifecycleActionHeartbeat({
+  await asg.recordLifecycleActionHeartbeat({
       AutoScalingGroupName: autoScalingGroupName, 
       LifecycleHookName: lifecycleHookName,
       LifecycleActionToken: lifecycleActionToken

--- a/ecs/lambda-drain-instance/lib.js
+++ b/ecs/lambda-drain-instance/lib.js
@@ -12,18 +12,18 @@ const queueUrl = process.env.QUEUE_URL;
 const drainingTimeout = process.env.DRAINING_TIMEOUT;
 
 async function getContainerInstanceArn(ec2InstanceId) {
-  console.log(`getContainerInstanceArn(${ec2InstanceId})`);
+  console.log("getContainerInstanceArn(", ...arguments, ")");
   const listResult = await ecs.listContainerInstances({cluster: cluster, filter: `ec2InstanceId == '${ec2InstanceId}'`}).promise();
   return listResult.containerInstanceArns[0];
 }
 
 async function drainInstance(containerInstanceArn) {
-  console.log(`drainInstance(${containerInstanceArn})`);
+  console.log("drainInstance(", ...arguments, ")");
   await ecs.updateContainerInstancesState({cluster: cluster, containerInstances: [containerInstanceArn], status: 'DRAINING'}).promise();
 }
 
 async function wait(containerInstanceArn, autoScalingGroupName, lifecycleHookName, lifecycleActionToken, terminateTime) {
-  console.log(`wait(${containerInstanceArn}, ${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken}, ${terminateTime})`);
+  console.log("wait(", ...arguments, ")");
   let payload = {
     Service: 'DrainInstance',
     Event: 'custom:DRAIN_WAIT',
@@ -41,7 +41,7 @@ async function wait(containerInstanceArn, autoScalingGroupName, lifecycleHookNam
 }
 
 async function deleteMessage(receiptHandle) {
-  console.log(`deleteMessage(${receiptHandle})`);
+  console.log("deleteMessage(", ...arguments, ")");
   await sqs.deleteMessage({
       QueueUrl: queueUrl,
       ReceiptHandle: receiptHandle
@@ -49,13 +49,13 @@ async function deleteMessage(receiptHandle) {
 }
 
 async function countTasks(containerInstanceArn) {
-  console.log(`countTasks(${containerInstanceArn})`);
+  console.log("countTasks(", ...arguments, ")");
   const listResult = await ecs.listTasks({cluster: cluster, containerInstance: containerInstanceArn}).promise();
   return listResult.taskArns.length;
 }
 
 async function terminateInstance(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
-  console.log(`terminateInstance(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
+  console.log("terminateInstance(", ...arguments, ")");
   await asg.completeLifecycleAction({
       AutoScalingGroupName: autoScalingGroupName, 
       LifecycleHookName: lifecycleHookName,
@@ -65,7 +65,7 @@ async function terminateInstance(autoScalingGroupName, lifecycleHookName, lifecy
 }
 
 async function heartbeat(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
-  console.log(`heartbeat(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
+  console.log("heartbeat(", ...arguments, ")");
   await asg.recordLifecycleActionHeartbeat({
       AutoScalingGroupName: autoScalingGroupName, 
       LifecycleHookName: lifecycleHookName,

--- a/ecs/lambda-drain-instance/lib.js
+++ b/ecs/lambda-drain-instance/lib.js
@@ -64,8 +64,8 @@ async function terminateInstance(autoScalingGroupName, lifecycleHookName, lifecy
     }).promise();
 }
 
-async function hearbeat(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
-  console.log(`hearbeat(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
+async function heartbeat(autoScalingGroupName, lifecycleHookName, lifecycleActionToken) {
+  console.log(`heartbeat(${autoScalingGroupName}, ${lifecycleHookName}, ${lifecycleActionToken})`);
   await asg.recordLifecycleActionHeartbeat({
       AutoScalingGroupName: autoScalingGroupName, 
       LifecycleHookName: lifecycleHookName,
@@ -93,7 +93,7 @@ exports.handler = async function(event, context) {
     } else {
       let actionDuration = Math.abs(new Date(body.TerminateTime).getTime() - new Date().getTime()) / 1000;
       if (actionDuration < drainingTimeout) {
-        await hearbeat(body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken);
+        await heartbeat(body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken);
         await wait(body.ContainerInstanceArn, body.AutoScalingGroupName, body.LifecycleHookName, body.LifecycleActionToken, body.TerminateTime);
       } else {
         console.log('Timeout for instance termination reached.');


### PR DESCRIPTION
Your PR guidelines request smaller changes, so I'm splitting this up into "stages".  Recommendation would be to skip #294 and #295 and use #296 :).
This is PR 2 of 3.  (1: #294, 3: #296)

Perform PR #294 _and_ ...

- Change how log statements are executed so can inspect the entire API payload.  This is far easier to debug because can track an individual lifecycle request without having to always filter CloudWatch Lambda execution logs via the Execution ID.

