### PR TITLE
[Bug Fix] security/account-password-policy - allow to disable MaxPasswordAge and PasswordReusePrevention

### DIFF
--- a/security/account-password-policy.yaml
+++ b/security/account-password-policy.yaml
@@ -52,8 +52,8 @@ Parameters:
     Description: 'You can set IAM user passwords to be valid for only the specified number of days.'
     Type: Number
     Default: 90
-    ConstraintDescription: 'Must be in the range [0-1095]'
-    MinValue: 0
+    ConstraintDescription: 'Must be in the range [1-1095]'
+    MinValue: 1
     MaxValue: 1095
   MinimumPasswordLength:
     Description: 'You can specify the minimum number of characters allowed in an IAM user password.'

--- a/security/account-password-policy.yaml
+++ b/security/account-password-policy.yaml
@@ -49,11 +49,11 @@ Parameters:
     - true
     - false
   MaxPasswordAge:
-    Description: 'You can set IAM user passwords to be valid for only the specified number of days.'
+    Description: 'You can set IAM user passwords to be valid for only the specified number of days. Choose 0 if you don not want passwords to expire.'
     Type: Number
     Default: 90
-    ConstraintDescription: 'Must be in the range [1-1095]'
-    MinValue: 1
+    ConstraintDescription: 'Must be in the range [0-1095]'
+    MinValue: 0
     MaxValue: 1095
   MinimumPasswordLength:
     Description: 'You can specify the minimum number of characters allowed in an IAM user password.'
@@ -148,17 +148,22 @@ Resources:
             if (event.RequestType === 'Delete') {
               iam.deleteAccountPasswordPolicy({}, done);
             } else if (event.RequestType === 'Create' || event.RequestType === 'Update') {
-              iam.updateAccountPasswordPolicy({
+              let params = {
                 AllowUsersToChangePassword: event.ResourceProperties.AllowUsersToChangePassword === 'true',
                 HardExpiry: event.ResourceProperties.HardExpiry === 'true',
-                MaxPasswordAge: parseInt(event.ResourceProperties.MaxPasswordAge, 10),
                 MinimumPasswordLength: parseInt(event.ResourceProperties.MinimumPasswordLength, 10),
-                PasswordReusePrevention: parseInt(event.ResourceProperties.PasswordReusePrevention, 10),
                 RequireLowercaseCharacters: event.ResourceProperties.RequireLowercaseCharacters === 'true',
                 RequireNumbers: event.ResourceProperties.RequireNumbers === 'true',
                 RequireSymbols: event.ResourceProperties.RequireSymbols === 'true',
                 RequireUppercaseCharacters: event.ResourceProperties.RequireUppercaseCharacters === 'true',
-              }, done);
+              };
+              if (parseInt(event.ResourceProperties.MaxPasswordAge, 10) > 0) {
+                params.MaxPasswordAge = parseInt(event.ResourceProperties.MaxPasswordAge, 10);
+              }
+              if (parseInt(event.ResourceProperties.PasswordReusePrevention, 10) > 0) {
+                params.PasswordReusePrevention = parseInt(event.ResourceProperties.PasswordReusePrevention, 10);
+              }
+              iam.updateAccountPasswordPolicy(params, done);
             } else {
               cb(new Error(`unsupported RequestType: ${event.RequestType}`));
             }


### PR DESCRIPTION
It was not possible to disable the expiry of passwords `MaxPasswordAge = 0` nor to disable the password reuse prevention `PasswordReusePrevention = 0`. Both parameters must be `> 0` (see https://docs.aws.amazon.com/IAM/latest/APIReference/API_PasswordPolicy.html). But both parameters are also optional.