### PR TITLE
[Improvement] state/rds-aurora-serverless - Support capacity of 1

### DIFF
--- a/state/rds-aurora-serverless.yaml
+++ b/state/rds-aurora-serverless.yaml
@@ -117,12 +117,12 @@ Parameters:
   MaxCapacity:
     Description: 'The maximum capacity units for a Serverless Aurora cluster.'
     Type: String
-    AllowedValues: [2, 4, 8, 16, 32, 64, 128, 256]
+    AllowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 256]
     Default: 2
   MinCapacity:
     Description: 'The minimum capacity units for a Serverless Aurora cluster.'
     Type: String
-    AllowedValues: [2, 4, 8, 16, 32, 64, 128, 256]
+    AllowedValues: [1, 2, 4, 8, 16, 32, 64, 128, 256]
     Default: 2
   SecondsUntilAutoPause:
     Description: 'The time, in seconds, before a Serverless Aurora cluster is paused.'


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2019/04/amazon_aurora_serverless_now_supports_a_minimum_capacity_of_1_unit_and_a_new_scaling_option/
