### PR TITLE
[Improvement] ecs/cluster - Avoid scaling deadlock

### DIFF
--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -809,6 +809,7 @@ Resources:
       LaunchConfigurationName: !Ref LaunchConfiguration
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
+      Cooldown: 60
       HealthCheckGracePeriod: 300
       HealthCheckType: ELB
       TargetGroupARNs:
@@ -937,19 +938,23 @@ Resources:
   ScaleUpPolicy:
     Type: 'AWS::AutoScaling::ScalingPolicy'
     Properties:
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      PolicyType: StepScaling
       AdjustmentType: PercentChangeInCapacity
       MinAdjustmentMagnitude: 1
-      AutoScalingGroupName: !Ref AutoScalingGroup
-      Cooldown: '600'
-      ScalingAdjustment: 25
+      StepAdjustments:
+      - MetricIntervalUpperBound: 0.0
+        ScalingAdjustment: 25
   ScaleDownPolicy:
     Type: 'AWS::AutoScaling::ScalingPolicy'
     Properties:
+      AutoScalingGroupName: !Ref AutoScalingGroup
+      PolicyType: StepScaling
       AdjustmentType: PercentChangeInCapacity
       MinAdjustmentMagnitude: 1
-      AutoScalingGroupName: !Ref AutoScalingGroup
-      Cooldown: '600'
-      ScalingAdjustment: -25
+      StepAdjustments:
+      - MetricIntervalLowerBound: 0.0
+        ScalingAdjustment: -25
   ContainerInstancesShortageAlarm:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -809,7 +809,7 @@ Resources:
       LaunchConfigurationName: !Ref LaunchConfiguration
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
-      Cooldown: '60'
+      Cooldown: '120'
       HealthCheckGracePeriod: 300
       HealthCheckType: ELB
       TargetGroupARNs:

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -809,7 +809,7 @@ Resources:
       LaunchConfigurationName: !Ref LaunchConfiguration
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
-      Cooldown: 60
+      Cooldown: '60'
       HealthCheckGracePeriod: 300
       HealthCheckType: ELB
       TargetGroupARNs:


### PR DESCRIPTION
The Auto Scaling Group managing the instance for the ECS cluster was using simple scaling. Unfortunately, a waiting lifecycle hook blocks any scaling actions. So while waiting for all tasks getting stopped on an ECS instance, no other scaling action was possible.

This change replaces simple scaling with step scaling. With step scaling a scaling action is possible even while a lifecycle hook is in state waiting. 