### PR TITLE
[Bug Fix] wordpress/* - Fixed missing logs:CreateLogGroup permission

### DIFF
--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -569,6 +569,7 @@ Resources:
             - 'logs:CreateLogStream'
             - 'logs:PutLogEvents'
             - 'logs:DescribeLogStreams'
+            - 'logs:CreateLogGroup'
             Resource: !GetAtt 'WebServerLogs.Arn'
   WebServerIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -555,6 +555,7 @@ Resources:
             - 'logs:CreateLogStream'
             - 'logs:PutLogEvents'
             - 'logs:DescribeLogStreams'
+            - 'logs:CreateLogGroup'
             Resource: !GetAtt 'WebServerLogs.Arn'
   WebServerIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'


### PR DESCRIPTION
…up failed with exception An error occurred (AccessDeniedException) when calling the CreateLogGroup operation: User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/wordpress-WebServerIAMRole-XXXXXXXXXXXXX/i-XXXXXXXXXXXXXXXXX is not authorized to perform: logs:CreateLogGroup on resource: arn:aws:logs:us-east-1:XXXXXXXXXXXX:log-group:wordpress-WebServerLogs-XXXXXXXXXXXXX:log-stream: error because of missing permissions

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

(describe your change here)
Fixed error related to missing CreateLogGroup role permission while creating WebServerIAMRole