### PR TITLE
[Bug Fix] static-website/lambdaedge-index-document - Support uppercase file endings

### DIFF
--- a/static-website/lambdaedge-index-document.yaml
+++ b/static-website/lambdaedge-index-document.yaml
@@ -66,7 +66,7 @@ Resources:
         # If you change the ZipFile, rename the logical id LambdaVersionV4 to trigger a new version creation!
         ZipFile: !Sub |
           'use strict';
-          const regex = /\.[a-z0-9]+$/;
+          const regex = /\.[A-Za-z0-9]+$/;
           const indexDocument = '${IndexDocument}';
           const domainName = '${DomainName}'.toLowerCase();
           const redirectDomainName = '${RedirectDomainName}'.toLowerCase();

--- a/static-website/lambdaedge-index-document.yaml
+++ b/static-website/lambdaedge-index-document.yaml
@@ -63,7 +63,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Code:
-        # If you change the ZipFile, rename the logical id LambdaVersionV4 to trigger a new version creation!
+        # If you change the ZipFile, rename the logical id LambdaVersionV5 to trigger a new version creation!
         ZipFile: !Sub |
           'use strict';
           const regex = /\.[A-Za-z0-9]+$/;
@@ -129,7 +129,7 @@ Resources:
     Properties:
       LogGroupName: !Sub '/aws/lambda/${LambdaFunction}'
       RetentionInDays: !Ref LogsRetentionInDays
-  LambdaVersionV4:
+  LambdaVersionV5:
     Type: 'AWS::Lambda::Version'
     Properties:
       FunctionName: !Ref LambdaFunction
@@ -145,4 +145,4 @@ Outputs:
     Value: !Sub '${AWS::StackName}'
   LambdaVersionArn:
     Description: 'Version ARN of Lambda@Edge function.'
-    Value: !Ref LambdaVersionV4
+    Value: !Ref LambdaVersionV5


### PR DESCRIPTION
Lambda on edge did not behave correctly for filenames with caps letters, for instance "/pic.JPG" would be redirected to "/pic.JPG/"