### PR TITLE
[Improvement] security/cloudtrail - Recording S3 data events

### DIFF
--- a/security/cloudtrail.yaml
+++ b/security/cloudtrail.yaml
@@ -37,10 +37,18 @@ Parameters:
     Description: 'Optional The log file prefix.'
     Type: String
     Default: ''
+  S3DataEvents:
+    Description: 'Record data events of all S3 buckets? (Warning: additional charges apply.)'
+    Type: String
+    Default: 'false'
+    AllowedValues:
+    - 'true'
+    - 'false'
 Conditions:
   InternalBucket: !Equals [!Ref ExternalTrailBucket, '']
   ExternalBucket: !Not [!Equals [!Ref ExternalTrailBucket, '']]
   HasLogFilePrefix: !Not [!Equals [!Ref LogFilePrefix, '']]
+  IsS3DataEvents: !Equals [!Ref S3DataEvents, 'true']
 Resources:
   TrailBucket:
     Condition: InternalBucket
@@ -121,8 +129,10 @@ Resources:
       IncludeGlobalServiceEvents: true
       IsLogging: true
       IsMultiRegionTrail: true
+      EventSelectors: !If [IsS3DataEvents, [{DataResources: [{Type: 'AWS::S3::Object', Values: ['arn:aws:s3:::']}], IncludeManagementEvents: true, ReadWriteType: All}], !Ref 'AWS::NoValue']
       S3BucketName: !Ref TrailBucket
       S3KeyPrefix: !Ref LogFilePrefix
+      EnableLogFileValidation: true
       CloudWatchLogsLogGroupArn: !GetAtt 'TrailLogGroup.Arn'
       CloudWatchLogsRoleArn: !GetAtt 'TrailLogGroupRole.Arn'
       SnsTopicName: !GetAtt 'TrailTopic.TopicName'
@@ -135,8 +145,10 @@ Resources:
       IncludeGlobalServiceEvents: true
       IsLogging: true
       IsMultiRegionTrail: true
+      EventSelectors: !If [IsS3DataEvents, [{DataResources: [{Type: 'AWS::S3::Object', Values: ['arn:aws:s3:::']}], IncludeManagementEvents: true, ReadWriteType: All}], !Ref 'AWS::NoValue']
       S3BucketName: !Ref ExternalTrailBucket
       S3KeyPrefix: !Ref LogFilePrefix
+      EnableLogFileValidation: true
       CloudWatchLogsLogGroupArn: !GetAtt 'TrailLogGroup.Arn'
       CloudWatchLogsRoleArn: !GetAtt 'TrailLogGroupRole.Arn'
       SnsTopicName: !GetAtt 'TrailTopic.TopicName'


### PR DESCRIPTION
Added option to record S3 data events with CloudTrail as well. Default is `false` as depending on the amount of S3 requests, recording the data events might be costly.