### PR TITLE
Get rid of managed policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ python:
 - '2.7'
 install:
 - 'pip install yamllint==1.15.0'
-- 'pip install awscli==1.16.104'
-- 'pip install cfn-lint==0.14.0'
+- 'pip install awscli==1.16.167'
+- 'pip install cfn-lint==0.21.3'
 script:
 - 'yamllint .'
-- 'cfn-lint -i E2520 E3002 W2001 W6001 -t ''**/*.yaml''' # TODO get rid of check ignores
+- 'cfn-lint -i E3002 W2001 W6001 -t ''**/*.yaml''' # TODO get rid of check ignores
 - 'find . -type f -name ''*.yaml'' | while read file; do set -ex && grep -q "LICENSE-2.0" "$file"; done;'
 - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then find . -type f -name ''*.yaml'' | while read file; do set -ex && aws s3 cp "$file" "s3://travis-aws-cf-templates/$TRAVIS_COMMIT/$file" && aws cloudformation validate-template --template-url "https://s3.amazonaws.com/travis-aws-cf-templates/$TRAVIS_COMMIT/$file" > /dev/null; done; fi'

--- a/docs/migrate-v10.md
+++ b/docs/migrate-v10.md
@@ -4,21 +4,19 @@
 
 # Migrate from v9 to v10
 
-> WARNING: Follow this guideline to avoid data loss!
+## *
 
-## fargate/service-cloudmap
+If you have `SystemsManagerAccess` set to `true`, we previously attached the managed policy `AmazonEC2RoleforSSM` but now only attach the following IAM permissions:
 
-* Rename parameter from `AmbassadorImage` to `ProxyImage`.
-* Rename parameter from `AmbassadorCommand` to `ProxyCommand`.
-* Rename parameter from `AmbassadorPort` to `ProxyPort`.
-* Rename parameter from `AmbassadorEnvironment1Key` to `ProxyEnvironment1Key`.
-* Rename parameter from `AmbassadorEnvironment1Value` to `ProxyEnvironment1Value`.
-* Rename parameter from `AmbassadorEnvironment2Key` to `ProxyEnvironment2Key`.
-* Rename parameter from `AmbassadorEnvironment2Value` to `ProxyEnvironment2Value`.
-* Rename parameter from `AmbassadorEnvironment3Key` to `ProxyEnvironment3Key`.
-* Rename parameter from `AmbassadorEnvironment3Value` to `ProxyEnvironment3Value`.
+* `ssmmessages:*`
+* `ssm:UpdateInstanceInformation`
+* `ec2messages:*`
 
-## fargate/service-cluster-alb
+This reducdes the permissions but is sufficient to make SSM Session Manager and Run Commands work.
+
+To restore the previous permissions (which are not following the least privilege principle), set the new parameter `ManagedPolicyArns` to `arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM`.
+
+## fargate/service-*
 
 * Rename parameter from `AmbassadorImage` to `ProxyImage`.
 * Rename parameter from `AmbassadorCommand` to `ProxyCommand`.
@@ -30,14 +28,8 @@
 * Rename parameter from `AmbassadorEnvironment3Key` to `ProxyEnvironment3Key`.
 * Rename parameter from `AmbassadorEnvironment3Value` to `ProxyEnvironment3Value`.
 
-## fargate/service-dedicated-alb
+## Deprecation warnings
 
-* Rename parameter from `AmbassadorImage` to `ProxyImage`.
-* Rename parameter from `AmbassadorCommand` to `ProxyCommand`.
-* Rename parameter from `AmbassadorPort` to `ProxyPort`.
-* Rename parameter from `AmbassadorEnvironment1Key` to `ProxyEnvironment1Key`.
-* Rename parameter from `AmbassadorEnvironment1Value` to `ProxyEnvironment1Value`.
-* Rename parameter from `AmbassadorEnvironment2Key` to `ProxyEnvironment2Key`.
-* Rename parameter from `AmbassadorEnvironment2Value` to `ProxyEnvironment2Value`.
-* Rename parameter from `AmbassadorEnvironment3Key` to `ProxyEnvironment3Key`.
-* Rename parameter from `AmbassadorEnvironment3Value` to `ProxyEnvironment3Value`.
+* `ecs/cluster`: The parameter `DesiredCapacity` will be removed in v11 (not needed anymore)
+* `jenkins/jenkins2-ha-agents`: The parameter `AgentDesiredCapacity` will be removed in v11 (not needed anymore)
+* `state/rds-aurora-serverless`: The parameter `Engine` will be removed in v11 (replaced by `EngineVersion`)

--- a/ec2/ec2-auto-recovery.yaml
+++ b/ec2/ec2-auto-recovery.yaml
@@ -42,6 +42,7 @@ Metadata:
       - IngressTcpPort1
       - IngressTcpPort2
       - IngressTcpPort3
+      - ManagedPolicyArns
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -134,6 +135,10 @@ Parameters:
     Description: 'Optional port allowing ingress TCP traffic.'
     Type: String
     Default: ''
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -182,6 +187,7 @@ Conditions:
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   RecordSet:
     Condition: HasZone
@@ -271,7 +277,6 @@ Resources:
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref IAMRole
   IAMRole:
@@ -282,13 +287,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: logs
         PolicyDocument:
           Version: '2012-10-17'

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1076,6 +1076,9 @@ Resources:
       - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
   # scaling based on SchedulableContainers is described in detail here: http://garbe.io/blog/2017/04/12/a-better-solution-to-ecs-autoscaling/
   SchedulableContainersCron:
+    DependsOn:
+    - SchedulableContainersLambdaPolicy
+    - SchedulableContainersLambdaPermission2
     Type: 'AWS::Events::Rule'
     Properties:
       ScheduleExpression: 'rate(1 minute)'
@@ -1111,14 +1114,6 @@ Resources:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
       Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'SchedulableContainersLogGroup.Arn'
       - PolicyName: ecs
         PolicyDocument:
           Statement:
@@ -1137,6 +1132,19 @@ Resources:
           - Effect: Allow
             Action: 'cloudwatch:PutMetricData'
             Resource: '*'
+  SchedulableContainersLambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref SchedulableContainersLambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'SchedulableContainersLogGroup.Arn'
   SchedulableContainersLambdaPermission2:
     Type: 'AWS::Lambda::Permission'
     Properties:

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -34,6 +34,7 @@ Metadata:
       - KeyName
       - IAMUserSSHAccess
       - SystemsManagerAccess
+      - ManagedPolicyArns
     - Label:
         default: 'Load Balancer Parameters'
       Parameters:
@@ -244,6 +245,7 @@ Conditions:
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   Cluster:
     Type: 'AWS::ECS::Cluster'
@@ -255,7 +257,6 @@ Resources:
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref Role
   Role:
@@ -268,9 +269,21 @@ Resources:
           Principal:
             Service: 'ec2.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: ecs
         PolicyDocument:
           Version: '2012-10-17'
@@ -914,11 +927,8 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'autoscaling.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
+            Service: 'autoscaling.amazonaws.com'
+          Action: 'sts:AssumeRole'
       Policies:
       - PolicyName: sqs
         PolicyDocument:

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1276,14 +1276,6 @@ Resources:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
       Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'DrainInstanceLogGroup.Arn'
       - PolicyName: draininstance
         PolicyDocument:
           Statement:
@@ -1311,7 +1303,23 @@ Resources:
             - 'autoscaling:CompleteLifecycleAction'
             - 'autoscaling:RecordLifecycleActionHeartbeat'
             Resource: !Sub 'arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AutoScalingGroup}'
+  DrainInstanceLambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref DrainInstanceLambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'DrainInstanceLogGroup.Arn'
   DrainInstanceEventSourceMapping:
+    DependsOn:
+    - DrainInstanceLambdaPolicy
+    - DrainInstanceLogGroup
     Type: 'AWS::Lambda::EventSourceMapping'
     Properties:
       BatchSize: 1

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -109,6 +109,10 @@ Parameters:
     AllowedValues:
     - true
     - false
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
   SubnetsReach:
     Description: 'Should the cluster have direct access to the Internet or do you prefer private subnets with NAT?'
     Type: String

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1110,9 +1110,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns: # TODO get rid of managed policy
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'SchedulableContainersLogGroup.Arn'
       - PolicyName: ecs
         PolicyDocument:
           Statement:
@@ -1261,9 +1267,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns: # TODO get rid of managed policy
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'DrainInstanceLogGroup.Arn'
       - PolicyName: draininstance
         PolicyDocument:
           Statement:

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -1078,7 +1078,6 @@ Resources:
   SchedulableContainersCron:
     DependsOn:
     - SchedulableContainersLambdaPolicy
-    - SchedulableContainersLambdaPermission2
     Type: 'AWS::Events::Rule'
     Properties:
       ScheduleExpression: 'rate(1 minute)'

--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -337,7 +337,6 @@ Resources:
           Principal:
             Service: 'application-autoscaling.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Path: '/'
       Policies:
       - PolicyName: ecs
         PolicyDocument:

--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -278,7 +278,7 @@ Resources:
   ServiceRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      ManagedPolicyArns: # TODO get rid of managed policy
+      ManagedPolicyArns:
       - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole'
       AssumeRolePolicyDocument:
         Version: '2008-10-17'

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -350,7 +350,7 @@ Resources:
   ServiceRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      ManagedPolicyArns: # TODO get rid of managed policy
+      ManagedPolicyArns:
       - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole'
       AssumeRolePolicyDocument:
         Version: '2008-10-17'

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -410,7 +410,6 @@ Resources:
           Principal:
             Service: 'application-autoscaling.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Path: '/'
       Policies:
       - PolicyName: ecs
         PolicyDocument:

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -377,9 +377,9 @@ Resources:
       DnsConfig:
         DnsRecords:
         - Type: A
-          TTL: '30'
+          TTL: 30
         - Type: SRV
-          TTL: '30'
+          TTL: 30
         NamespaceId: {'Fn::ImportValue': !Sub '${ParentCloudMapStack}-NamespaceID'}
         RoutingPolicy: MULTIVALUE
       HealthCheckCustomConfig:

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -33,6 +33,7 @@ Metadata:
       - IAMUserSSHAccess
       - SystemsManagerAccess
       - SubDomainNameWithDot
+      - ManagedPolicyArns
     - Label:
         default: 'Master Parameters'
       Parameters:
@@ -190,6 +191,10 @@ Parameters:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
     Default: 'jenkins.'
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -237,6 +242,7 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   MasterStorageSG:
     Type: 'AWS::EC2::SecurityGroup'
@@ -464,7 +470,6 @@ Resources:
   MasterIP:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref MasterIAMRole
   MasterIAMRole:
@@ -475,13 +480,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: cloudwatch
         PolicyDocument:
           Version: '2012-10-17'
@@ -525,10 +540,8 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Effect: Allow
-            Action:
-            - 'sts:AssumeRole'
-            Resource:
-            - '*'
+            Action: 'sts:AssumeRole'
+            Resource: '*'
   MasterIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'
     Condition: HasIAMUserSSHAccess
@@ -1353,7 +1366,6 @@ Resources:
   AgentIP:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref AgentIAMRole
   AgentIAMRole:
@@ -1364,13 +1376,22 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: /
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: ec2
         PolicyDocument:
           Version: '2012-10-17'
@@ -1397,10 +1418,8 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Effect: Allow
-            Action:
-            - 'sts:AssumeRole'
-            Resource:
-            - '*'
+            Action: 'sts:AssumeRole'
+            Resource: '*'
   AgentIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'
     Condition: HasIAMUserSSHAccess
@@ -2039,11 +2058,8 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'autoscaling.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
+            Service: 'autoscaling.amazonaws.com'
+          Action: 'sts:AssumeRole'
       Policies:
       - PolicyName: sqs
         PolicyDocument:

--- a/jenkins/jenkins2-ha.yaml
+++ b/jenkins/jenkins2-ha.yaml
@@ -33,6 +33,7 @@ Metadata:
       - IAMUserSSHAccess
       - SystemsManagerAccess
       - SubDomainNameWithDot
+      - ManagedPolicyArns
     - Label:
         default: 'Master Parameters'
       Parameters:
@@ -130,6 +131,10 @@ Parameters:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
     Default: 'jenkins.'
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -176,6 +181,7 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   MasterStorageSG:
     Type: 'AWS::EC2::SecurityGroup'
@@ -403,7 +409,6 @@ Resources:
   MasterIP:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref MasterIAMRole
   MasterIAMRole:
@@ -414,13 +419,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: logs
         PolicyDocument:
           Version: '2012-10-17'
@@ -437,10 +452,8 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Effect: Allow
-            Action:
-            - 'sts:AssumeRole'
-            Resource:
-            - '*'
+            Action: 'sts:AssumeRole'
+            Resource: '*'
   MasterIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'
     Condition: HasIAMUserSSHAccess

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ pages:
   - 'WordPress': 'wordpress.md'
 - 'widdix CLI': 'cli.md'
 - 'Migration Guides':
+  - 'Migrate to v10': 'migrate-v10.md'
   - 'Migrate to v9': 'migrate-v9.md'
   - 'Migrate to v8': 'migrate-v8.md'
   - 'Migrate to v7': 'migrate-v7.md'

--- a/operations/backup-dynamodb-native.yaml
+++ b/operations/backup-dynamodb-native.yaml
@@ -54,9 +54,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns: # TODO get rid of managed policy
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LambdaLogGroup.Arn'
       - PolicyName: dynamodb
         PolicyDocument:
           Statement:

--- a/operations/backup-dynamodb-native.yaml
+++ b/operations/backup-dynamodb-native.yaml
@@ -75,9 +75,7 @@ Resources:
           - 'logs:PutLogEvents'
           Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaRule:
-    DependsOn:
-    - LambdaPolicy
-    - LambdaPermission
+    DependsOn: LambdaPolicy
     Type: 'AWS::Events::Rule'
     Properties:
       ScheduleExpression: 'rate(1 day)'

--- a/operations/backup-dynamodb-native.yaml
+++ b/operations/backup-dynamodb-native.yaml
@@ -55,21 +55,29 @@ Resources:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
       Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LambdaLogGroup.Arn'
       - PolicyName: dynamodb
         PolicyDocument:
           Statement:
           - Effect: Allow
             Action: 'dynamodb:CreateBackup'
             Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TableName}'
+  LambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref LambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaRule:
+    DependsOn:
+    - LambdaPolicy
+    - LambdaPermission
     Type: 'AWS::Events::Rule'
     Properties:
       ScheduleExpression: 'rate(1 day)'

--- a/security/account-password-policy.yaml
+++ b/security/account-password-policy.yaml
@@ -113,9 +113,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns: # TODO get rid of managed policy
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LambdaLogGroup.Arn'
       - PolicyName: iam
         PolicyDocument:
           Statement:

--- a/security/account-password-policy.yaml
+++ b/security/account-password-policy.yaml
@@ -112,9 +112,7 @@ Resources:
         - Effect: Allow
           Principal:
             Service: 'lambda.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
+          Action: 'sts:AssumeRole'
       ManagedPolicyArns: # TODO get rid of managed policy
       - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:

--- a/security/account-password-policy.yaml
+++ b/security/account-password-policy.yaml
@@ -114,14 +114,6 @@ Resources:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
       Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LambdaLogGroup.Arn'
       - PolicyName: iam
         PolicyDocument:
           Statement:
@@ -130,6 +122,19 @@ Resources:
             - 'iam:UpdateAccountPasswordPolicy'
             - 'iam:DeleteAccountPasswordPolicy'
             Resource: '*'
+  LambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref LambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunctionV2: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:
@@ -184,7 +189,9 @@ Resources:
       RetentionInDays: !Ref LogsRetentionInDays
   PasswordPolicy:
     Type: 'Custom::PasswordPolicy'
-    DependsOn: LambdaLogGroup
+    DependsOn:
+    - LambdaLogGroup
+    - LambdaPolicy
     Version: '1.0'
     Properties:
       HardExpiry: !Ref HardExpiry

--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -43,6 +43,7 @@ Metadata:
       - SystemsManagerAccess
       - LogsRetentionInDays
       - SubDomainNameWithDot
+      - ManagedPolicyArns
     - Label:
         default: 'Load Balancer Parameters'
       Parameters:
@@ -118,6 +119,10 @@ Parameters:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
     Default: 'secure.'
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
   LoadBalancerIdleTimeout:
     Description: 'The idle timeout value, in seconds.'
     Type: Number
@@ -167,6 +172,7 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   Logs:
     Type: 'AWS::Logs::LogGroup'
@@ -387,7 +393,6 @@ Resources:
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref IAMRole
   IAMRole:
@@ -398,13 +403,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: /
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: logs
         PolicyDocument:
           Version: '2012-10-17'

--- a/security/config.yaml
+++ b/security/config.yaml
@@ -59,7 +59,7 @@ Resources:
     Condition: InternalBucket
     Type: 'AWS::IAM::Role'
     Properties:
-      ManagedPolicyArns: # TODO get rid of managed policy
+      ManagedPolicyArns:
       - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -94,7 +94,7 @@ Resources:
     Condition: ExternalBucket
     Type: 'AWS::IAM::Role'
     Properties:
-      ManagedPolicyArns: # TODO get rid of managed policy
+      ManagedPolicyArns:
       - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'

--- a/state/dynamodb.yaml
+++ b/state/dynamodb.yaml
@@ -135,8 +135,7 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-              'application-autoscaling.amazonaws.com'
+            Service: 'application-autoscaling.amazonaws.com'
           Action: 'sts:AssumeRole'
       Policies:
       - PolicyName: scaling

--- a/state/elasticache-memcached.yaml
+++ b/state/elasticache-memcached.yaml
@@ -222,8 +222,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns:
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'CustomResourceLambdaLogGroup.Arn'
   CustomResourceLambdaFunction: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/state/elasticache-memcached.yaml
+++ b/state/elasticache-memcached.yaml
@@ -222,15 +222,19 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'CustomResourceLambdaLogGroup.Arn'
+  CustomResourceLambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref CustomResourceLambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'CustomResourceLambdaLogGroup.Arn'
   CustomResourceLambdaFunction: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:
@@ -258,7 +262,9 @@ Resources:
       RetentionInDays: !Ref LogsRetentionInDays
   PreferredAvailabilityZonesSelector:
     Type: 'Custom::PreferredAvailabilityZonesSelector'
-    DependsOn: CustomResourceLambdaLogGroup
+    DependsOn:
+    - CustomResourceLambdaLogGroup
+    - CustomResourceLambdaPolicy
     Version: '1.0'
     Properties:
       NumCacheNodes: !Ref NumCacheNodes

--- a/static-website/lambdaedge-index-document.yaml
+++ b/static-website/lambdaedge-index-document.yaml
@@ -57,8 +57,15 @@ Resources:
             - 'lambda.amazonaws.com'
             - 'edgelambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns: # TODO get rid of managed policy
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/static-website/lambdaedge-index-document.yaml
+++ b/static-website/lambdaedge-index-document.yaml
@@ -57,15 +57,19 @@ Resources:
             - 'lambda.amazonaws.com'
             - 'edgelambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LambdaLogGroup.Arn'
+  LambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref LambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/vpc/vpc-flow-logs.yaml
+++ b/vpc/vpc-flow-logs.yaml
@@ -52,8 +52,7 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'vpc-flow-logs.amazonaws.com'
+            Service: 'vpc-flow-logs.amazonaws.com'
           Action: 'sts:AssumeRole'
       Policies:
       - PolicyName: 'flowlogs-policy'

--- a/vpc/vpc-nat-instance.yaml
+++ b/vpc/vpc-nat-instance.yaml
@@ -34,6 +34,7 @@ Metadata:
       # TODO - SystemsManagerAccess
       - LogsRetentionInDays
       - SubDomainNameWithDot
+      - ManagedPolicyArns
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -83,6 +84,10 @@ Parameters:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
     Default: 'nat.'
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
 Mappings:
   RegionMap: # TODO update to Amazon Linux 2 (don't forget to adjust awslogs config as well)
     'ap-south-1':
@@ -124,6 +129,7 @@ Conditions:
   HasNotSSHBastionSecurityGroup: !Equals [!Ref ParentSSHBastionStack, '']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   RecordSet:
     Condition: HasZone
@@ -198,7 +204,6 @@ Resources:
   NATInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref NATIAMRole
   NATIAMRole:
@@ -209,11 +214,9 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
       - PolicyName: ec2
         PolicyDocument:

--- a/vpc/vpc-ssh-bastion.yaml
+++ b/vpc/vpc-ssh-bastion.yaml
@@ -32,6 +32,7 @@ Metadata:
       - SystemsManagerAccess
       - LogsRetentionInDays
       - SubDomainNameWithDot
+      - ManagedPolicyArns
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -75,6 +76,10 @@ Parameters:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
     Default: 'ssh.'
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -115,6 +120,7 @@ Conditions:
   HasSystemsManagerAccess: !Equals [!Ref SystemsManagerAccess, 'true']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   RecordSet:
     Condition: HasZone
@@ -150,7 +156,6 @@ Resources:
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref IAMRole
   IAMRole:
@@ -161,13 +166,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: 'ec2'
         PolicyDocument:
           Version: '2012-10-17'

--- a/vpc/vpc-vpn-bastion.yaml
+++ b/vpc/vpc-vpn-bastion.yaml
@@ -32,6 +32,7 @@ Metadata:
       - SystemsManagerAccess
       - LogsRetentionInDays
       - SubDomainNameWithDot
+      - ManagedPolicyArns
     - Label:
         default: 'VPN Parameters'
       Parameters:
@@ -82,6 +83,10 @@ Parameters:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
     Default: 'vpn.'
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
   VPNPSK:
     Description: 'Specify the IPsec Pre-Shared Key.'
     Type: String
@@ -137,6 +142,7 @@ Conditions:
   HasSystemsManagerAccess: !Equals [!Ref SystemsManagerAccess, 'true']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   StorageSG:
     Type: 'AWS::EC2::SecurityGroup'
@@ -277,8 +283,21 @@ Resources:
           Principal:
             Service: 'ec2.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: 'ec2'
         PolicyDocument:
           Version: '2012-10-17'

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -1127,8 +1127,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns:
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunction: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -47,6 +47,7 @@ Metadata:
       - WebServerSystemsManagerAccess
       - WebServerInstanceType
       - WebServerLogsRetentionInDays
+      - ManagedPolicyArns
     - Label:
         default: 'EFS Parameters'
       Parameters:
@@ -134,6 +135,10 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
   EFSProvisionedThroughputInMibps:
     Description: 'The provisioned throughput for the Elastic File System (EFS) in Mibps. Default is 0 which enables the bursting mode and disables provisioned throughput.'
     Type: Number
@@ -211,6 +216,7 @@ Conditions:
   HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0']
   HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
   HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   WebServerLogs:
     Type: 'AWS::Logs::LogGroup'
@@ -542,7 +548,6 @@ Resources:
   WebServerInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref WebServerIAMRole
   WebServerIAMRole:
@@ -553,13 +558,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: logs
         PolicyDocument:
           Version: '2012-10-17'
@@ -1111,9 +1126,7 @@ Resources:
         - Effect: Allow
           Principal:
             Service: 'lambda.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
+          Action: 'sts:AssumeRole'
       ManagedPolicyArns:
       - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   LambdaFunction: # needs no monitoring because it is used as a custom resource

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -1127,15 +1127,19 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LambdaLogGroup.Arn'
+  LambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref LambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunction: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:
@@ -1160,7 +1164,9 @@ Resources:
       RetentionInDays: !Ref WebServerLogsRetentionInDays
   MaxThroughputCalculator:
     Type: 'Custom::MaxThroughputCalculator'
-    DependsOn: LambdaLogGroup
+    DependsOn:
+    - LambdaLogGroup
+    - LambdaPolicy
     Version: '1.0'
     Properties:
       ThroughputInMibps: !Ref EFSProvisionedThroughputInMibps

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -47,6 +47,7 @@ Metadata:
       - WebServerSystemsManagerAccess
       - WebServerInstanceType
       - WebServerLogsRetentionInDays
+      - ManagedPolicyArns
     - Label:
         default: 'EFS Parameters'
       Parameters:
@@ -134,6 +135,10 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  ManagedPolicyArns:
+    Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the instance''s IAM role'
+    Type: String
+    Default: ''
   EFSProvisionedThroughputInMibps:
     Description: 'The provisioned throughput for the Elastic File System (EFS) in Mibps. Default is 0.0 which enables the bursting mode and disables provisioned throughput.'
     Type: Number
@@ -211,6 +216,7 @@ Conditions:
   HasNotEFSProvisionedThroughput: !Equals [!Ref EFSProvisionedThroughputInMibps, '0.0']
   HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
   HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
+  HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
 Resources:
   WebServerLogs:
     Type: 'AWS::Logs::LogGroup'
@@ -528,7 +534,6 @@ Resources:
   WebServerInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      Path: '/'
       Roles:
       - !Ref WebServerIAMRole
   WebServerIAMRole:
@@ -539,13 +544,23 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            Service:
-            - 'ec2.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
-      ManagedPolicyArns: !If [HasSystemsManagerAccess, ['arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'], []] # TODO get rid of managed policy
+            Service: 'ec2.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasManagedPolicyArns, !Split [',', !Ref ManagedPolicyArns], !Ref 'AWS::NoValue']
       Policies:
+      - !If
+        - HasSystemsManagerAccess
+        - PolicyName: ssm
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              Resource: '*'
+        - !Ref 'AWS::NoValue'
       - PolicyName: logs
         PolicyDocument:
           Version: '2012-10-17'
@@ -1087,9 +1102,7 @@ Resources:
         - Effect: Allow
           Principal:
             Service: 'lambda.amazonaws.com'
-          Action:
-          - 'sts:AssumeRole'
-      Path: '/'
+          Action: 'sts:AssumeRole'
       ManagedPolicyArns:
       - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   LambdaFunction: # needs no monitoring because it is used as a custom resource

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -1103,15 +1103,19 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: lambda
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LambdaLogGroup.Arn'
+  LambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      Roles:
+      - !Ref LambdaRole
+      PolicyName: lambda
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+          - 'logs:CreateLogStream'
+          - 'logs:PutLogEvents'
+          Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunction: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:
@@ -1136,7 +1140,9 @@ Resources:
       RetentionInDays: !Ref WebServerLogsRetentionInDays
   MaxThroughputCalculator:
     Type: 'Custom::MaxThroughputCalculator'
-    DependsOn: LambdaLogGroup
+    DependsOn:
+    - LambdaLogGroup
+    - LambdaPolicy
     Version: '1.0'
     Properties:
       ThroughputInMibps: !Ref EFSProvisionedThroughputInMibps

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -1103,8 +1103,15 @@ Resources:
           Principal:
             Service: 'lambda.amazonaws.com'
           Action: 'sts:AssumeRole'
-      ManagedPolicyArns:
-      - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+      - PolicyName: lambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LambdaLogGroup.Arn'
   LambdaFunction: # needs no monitoring because it is used as a custom resource
     Type: 'AWS::Lambda::Function'
     Properties:


### PR DESCRIPTION
Breaking change because we reduce the permissions if SSM is enabled.
Workaround: Passt SSM managed policy as new parameter