### PR TITLE
Add missing ssm agent permission in EC2 IAM Role

### DIFF
--- a/ec2/ec2-auto-recovery.yaml
+++ b/ec2/ec2-auto-recovery.yaml
@@ -301,6 +301,8 @@ Resources:
               Action:
               - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
               - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:ListAssociations'
+              - 'ssm:ListInstanceAssociations'
               - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
               Resource: '*'
         - !Ref 'AWS::NoValue'


### PR DESCRIPTION
After trying this template into a private subnet and a bastion I was getting these errors:
```
ERROR [MessagingDeliveryService] [Association] Unable to load instance associations, unable to retrieve associations unable to retrieve associations AccessDeniedException: User ...  is not authorized to perform: ssm:ListAssociations
```

and same for `ssm:ListInstanceAssociations`

So I added the following permissions to fix it:
- ListAssociations
- ListInstanceAssociations

Also you should mention in the doc that deploying the `ec2-autorecovery` template requires the NAT gateway template if deployed in a private subnet

Thanks


