### PR TITLE
Give ParentClientStack default empty for optional

### DIFF
--- a/vpc/vpc-endpoint.yaml
+++ b/vpc/vpc-endpoint.yaml
@@ -31,8 +31,9 @@ Parameters:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
     Type: String
   ParentClientStack:
-    Description: 'Optionel stack name of parent client stack based on state/client-sg.yaml template.'
+    Description: 'Optional stack name of parent client stack based on state/client-sg.yaml template.'
     Type: String
+    Default: ''
   ServiceName:
     Description: 'The name of the service.'
     Type: String


### PR DESCRIPTION
Fixes `An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameters: [ParentClientStack] must have values`