### PR TITLE
Update vpc-vpn-bastion.yaml

### DIFF
--- a/vpc/vpc-vpn-bastion.yaml
+++ b/vpc/vpc-vpn-bastion.yaml
@@ -298,7 +298,7 @@ Resources:
       - CidrIp: 0.0.0.0/0
         IpProtocol: udp
         FromPort: 40000
-        ToPort: 40000
+        ToPort: 44999
       - CidrIp: 0.0.0.0/0
         IpProtocol: udp
         FromPort: 500

--- a/vpc/vpc-vpn-bastion.yaml
+++ b/vpc/vpc-vpn-bastion.yaml
@@ -297,6 +297,10 @@ Resources:
         ToPort: 5555
       - CidrIp: 0.0.0.0/0
         IpProtocol: udp
+        FromPort: 40000
+        ToPort: 40000
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: udp
         FromPort: 500
         ToPort: 500
       - CidrIp: 0.0.0.0/0


### PR DESCRIPTION
Add UDP port 40000. vpnclient uses this port for UDP acceleration.
Mobile clients work fine, but connecting from Linux using default client settings, connection will "freeze".
Once port 40000 is allowed in security group, browsing is perfect.
https://github.com/SoftEtherVPN/SoftEtherVPN/issues/544