### PR TITLE
Add `fargate/service` template for services that do not require Service Discovery

### DIFF
--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -271,104 +271,9 @@ Parameters:
     Type: String
     Default: 'true'
     AllowedValues: ['true', 'false']
-Mappings:
-  CpuMap:
-    '0.25':
-      Cpu: 256
-    '0.5':
-      Cpu: 512
-    '1':
-      Cpu: 1024
-    '2':
-      Cpu: 2048
-    '4':
-      Cpu: 4096
-  MemoryMap:
-    '0.5':
-      Memory: 512
-    '1':
-      Memory: 1024
-    '2':
-      Memory: 2048
-    '3':
-      Memory: 3072
-    '4':
-      Memory: 4096
-    '5':
-      Memory: 5120
-    '6':
-      Memory: 6144
-    '7':
-      Memory: 7168
-    '8':
-      Memory: 8192
-    '9':
-      Memory: 9216
-    '10':
-      Memory: 10240
-    '11':
-      Memory: 11264
-    '12':
-      Memory: 12288
-    '13':
-      Memory: 13312
-    '14':
-      Memory: 14336
-    '15':
-      Memory: 15360
-    '16':
-      Memory: 16384
-    '17':
-      Memory: 17408
-    '18':
-      Memory: 18432
-    '19':
-      Memory: 19456
-    '20':
-      Memory: 20480
-    '21':
-      Memory: 21504
-    '22':
-      Memory: 22528
-    '23':
-      Memory: 23552
-    '24':
-      Memory: 24576
-    '25':
-      Memory: 25600
-    '26':
-      Memory: 26624
-    '27':
-      Memory: 27648
-    '28':
-      Memory: 28672
-    '29':
-      Memory: 29696
-    '30':
-      Memory: 30720
 Conditions:
-  HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
-  HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
-  HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
-  HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
-  HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
-  HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
-  HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
-  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
-  HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
-  HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
-  HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
   HasProxyImage: !Not [!Equals [!Ref ProxyImage, '']]
-  HasProxyCommand: !Not [!Equals [!Ref ProxyCommand, '']]
-  HasProxyEnvironment1Key: !Not [!Equals [!Ref ProxyEnvironment1Key, '']]
-  HasProxyEnvironment2Key: !Not [!Equals [!Ref ProxyEnvironment2Key, '']]
-  HasProxyEnvironment3Key: !Not [!Equals [!Ref ProxyEnvironment3Key, '']]
-  HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
-  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
-  HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
-  HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
-  HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
 Resources:
   ServiceDiscovery:
     Type: 'AWS::ServiceDiscovery::Service'
@@ -386,113 +291,6 @@ Resources:
         FailureThreshold: 1
       Name: !Ref Name
       NamespaceId: {'Fn::ImportValue': !Sub '${ParentCloudMapStack}-NamespaceID'}
-  TaskExecutionRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'ecs-tasks.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: AmazonECSTaskExecutionRolePolicy # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'ecr:GetAuthorizationToken'
-            - 'ecr:BatchCheckLayerAvailability'
-            - 'ecr:GetDownloadUrlForLayer'
-            - 'ecr:BatchGetImage'
-            Resource: '*'
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LogGroup.Arn'
-  TaskRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'ecs-tasks.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      ManagedPolicyArns: !If [HasTaskPolicies, !Split [',', !Ref TaskPolicies], !Ref 'AWS::NoValue']
-  TaskDefinition:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      ContainerDefinitions:
-      - !If
-        - HasProxyImage
-        - Name: proxy
-          Image: !Ref ProxyImage
-          Command: !If [HasProxyCommand, !Ref ProxyCommand, !Ref 'AWS::NoValue']
-          PortMappings:
-          - ContainerPort: !Ref ProxyPort
-            Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              'awslogs-region': !Ref 'AWS::Region'
-              'awslogs-group': !Ref LogGroup
-              'awslogs-stream-prefix': proxy
-          Environment:
-          - !If [HasProxyEnvironment1Key, {Name: !Ref ProxyEnvironment1Key, Value: !Ref ProxyEnvironment1Value}, !Ref 'AWS::NoValue']
-          - !If [HasProxyEnvironment2Key, {Name: !Ref ProxyEnvironment2Key, Value: !Ref ProxyEnvironment2Value}, !Ref 'AWS::NoValue']
-          - !If [HasProxyEnvironment3Key, {Name: !Ref ProxyEnvironment3Key, Value: !Ref ProxyEnvironment3Value}, !Ref 'AWS::NoValue']
-        - !Ref 'AWS::NoValue'
-      - Name: app
-        Image: !Ref AppImage
-        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
-        PortMappings:
-        - ContainerPort: !Ref AppPort
-          Protocol: tcp
-        Essential: true
-        LogConfiguration:
-          LogDriver: awslogs
-          Options:
-            'awslogs-region': !Ref 'AWS::Region'
-            'awslogs-group': !Ref LogGroup
-            'awslogs-stream-prefix': app
-        Environment:
-        - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
-        - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
-        - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
-      - !If
-        - HasSidecarImage
-        - Name: sidecar
-          Image: !Ref SidecarImage
-          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
-          PortMappings:
-          - ContainerPort: !Ref SidecarPort
-            Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              'awslogs-region': !Ref 'AWS::Region'
-              'awslogs-group': !Ref LogGroup
-              'awslogs-stream-prefix': sidecar
-          Environment:
-          - !If [HasSidecarEnvironment1Key, {Name: !Ref SidecarEnvironment1Key, Value: !Ref SidecarEnvironment1Value}, !Ref 'AWS::NoValue']
-          - !If [HasSidecarEnvironment2Key, {Name: !Ref SidecarEnvironment2Key, Value: !Ref SidecarEnvironment2Value}, !Ref 'AWS::NoValue']
-          - !If [HasSidecarEnvironment3Key, {Name: !Ref SidecarEnvironment3Key, Value: !Ref SidecarEnvironment3Value}, !Ref 'AWS::NoValue']
-        - !Ref 'AWS::NoValue'
-      Cpu: !FindInMap [CpuMap, !Ref Cpu, Cpu]
-      ExecutionRoleArn: !GetAtt 'TaskExecutionRole.Arn'
-      Family: !Ref 'AWS::StackName'
-      Memory: !FindInMap [MemoryMap, !Ref Memory, Memory]
-      NetworkMode: awsvpc
-      RequiresCompatibilities: [FARGATE]
-      TaskRoleArn: !GetAtt 'TaskRole.Arn'
-  LogGroup:
-    Type: 'AWS::Logs::LogGroup'
-    Properties:
-      RetentionInDays: !Ref LogsRetentionInDays
   ServiceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -513,159 +311,59 @@ Resources:
       ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
       SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentSSHBastionStack}-SecurityGroup'}
   Service:
-    Type: 'AWS::ECS::Service'
+    Type: 'AWS::CloudFormation::Stack'
     Properties:
-      Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      DeploymentConfiguration:
-        MaximumPercent: 200
-        MinimumHealthyPercent: 100
-      DesiredCount: !Ref DesiredCount
-      LaunchType: FARGATE
-      ServiceRegistries:
-      - ContainerName: !If [HasProxyImage, proxy, app]
-        ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
-        RegistryArn: !GetAtt 'ServiceDiscovery.Arn'
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: !If [HasSubnetsReachPublic, ENABLED, DISABLED]
-          SecurityGroups:
-          - !Ref ServiceSecurityGroup
-          - !If [HasClientSecurityGroup1, {'Fn::ImportValue': !Sub '${ParentClientStack1}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          - !If [HasClientSecurityGroup2, {'Fn::ImportValue': !Sub '${ParentClientStack2}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          - !If [HasClientSecurityGroup3, {'Fn::ImportValue': !Sub '${ParentClientStack3}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          Subnets: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-Subnets${SubnetsReach}'}]
-      TaskDefinition: !Ref TaskDefinition
-  CPUUtilizationTooHighAlarm:
-    Condition: HasAlertTopic
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Average CPU utilization over last 10 minutes higher than 80%'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 80
-      AlarmActions:
-      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
-  ScalableTargetRole: # based on http://docs.aws.amazon.com/AmazonECS/latest/developerguide/autoscale_IAM_role.html
-    Condition: HasAutoScaling
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'application-autoscaling.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: AmazonEC2ContainerServiceAutoscaleRole
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'ecs:DescribeServices'
-            - 'ecs:UpdateService'
-            Resource: '*'
-      - PolicyName: cloudwatch
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'cloudwatch:DescribeAlarms'
-            Resource: '*'
-  ScalableTarget:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
-    Properties:
-      MaxCapacity: !Ref MaxCapacity
-      MinCapacity: !Ref MinCapacity
-      ResourceId: !Sub
-      - 'service/${Cluster}/${Service}'
-      - Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-        Service: !GetAtt 'Service.Name'
-      RoleARN: !GetAtt 'ScalableTargetRole.Arn'
-      ScalableDimension: 'ecs:service:DesiredCount'
-      ServiceNamespace: ecs
-  ScaleUpPolicy:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
-    Properties:
-      PolicyName: !Sub '${AWS::StackName}-scale-up'
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref ScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 300
-        MinAdjustmentMagnitude: 1
-        StepAdjustments:
-        - MetricIntervalLowerBound: 0
-          ScalingAdjustment: 25
-  ScaleDownPolicy:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
-    Properties:
-      PolicyName: !Sub '${AWS::StackName}-scale-down'
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref ScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 300
-        MinAdjustmentMagnitude: 1
-        StepAdjustments:
-        - MetricIntervalUpperBound: 0
-          ScalingAdjustment: -25
-  CPUUtilizationHighAlarm:
-    Condition: HasAutoScaling
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Service is running out of CPU'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 60
-      AlarmActions:
-      - !Ref ScaleUpPolicy
-  CPUUtilizationLowAlarm:
-    Condition: HasAutoScaling
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Service is wasting CPU'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: LessThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 3
-      Threshold: 30
-      AlarmActions:
-      - !Ref ScaleDownPolicy
+      Parameters:
+        ServiceDiscoveryARN: !GetAtt 'ServiceDiscovery.Arn'
+        ParentVPCStack: !Ref ParentVPCStack
+        ServiceSecurityGroup: !Ref ServiceSecurityGroup
+        ParentClusterStack: !Ref ParentClusterStack
+        ParentAlertStack: !Ref ParentAlertStack
+        ParentClientStack: !Ref ParentClientStack
+        ParentClientStack1: !Ref ParentClientStack1
+        ParentClientStack2: !Ref ParentClientStack2
+        ParentClientStack3: !Ref ParentClientStack3
+        TaskPolicies: !Ref TaskPolicies
+        ProxyImage: !Ref ProxyImage
+        ProxyCommand: !Ref ProxyCommand
+        ProxyPort: !Ref ProxyPort
+        ProxyEnvironment1Key: !Ref ProxyEnvironment1Key
+        ProxyEnvironment1Value: !Ref ProxyEnvironment1Value
+        ProxyEnvironment2Key: !Ref ProxyEnvironment2Key
+        ProxyEnvironment2Value: !Ref ProxyEnvironment2Value
+        ProxyEnvironment3Key: !Ref ProxyEnvironment3Key
+        ProxyEnvironment3Value: !Ref ProxyEnvironment3Value
+        AppImage: !Ref AppImage
+        AppCommand: !Ref AppCommand
+        AppPort: !Ref AppPort
+        AppEnvironment1Key: !Ref AppEnvironment1Key
+        AppEnvironment1Value: !Ref AppEnvironment1Value
+        AppEnvironment2Key: !Ref AppEnvironment2Key
+        AppEnvironment2Value: !Ref AppEnvironment2Value
+        AppEnvironment3Key: !Ref AppEnvironment3Key
+        AppEnvironment3Value: !Ref AppEnvironment3Value
+        SidecarImage: !Ref SidecarImage
+        SidecarCommand: !Ref SidecarCommand
+        SidecarPort: !Ref SidecarPort
+        SidecarEnvironment1Key: !Ref SidecarEnvironment1Key
+        SidecarEnvironment1Value: !Ref SidecarEnvironment1Value
+        SidecarEnvironment2Key: !Ref SidecarEnvironment2Key
+        SidecarEnvironment2Value: !Ref SidecarEnvironment2Value
+        SidecarEnvironment3Key: !Ref SidecarEnvironment3Key
+        SidecarEnvironment3Value: !Ref SidecarEnvironment3Value
+        Cpu: !Ref Cpu
+        Memory: !Ref Memory
+        SubnetsReach: !Ref SubnetsReach
+        AutoScaling: !Ref AutoScaling
+        DesiredCount: !Ref DesiredCount
+        MaxCapacity: !Ref MaxCapacity
+        MinCapacity: !Ref MinCapacity
+        LogsRetentionInDays: !Ref LogsRetentionInDays
+      TemplateURL: './service.yaml'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'
-    Value: 'fargate/service-cloudmap'
+    Value: 'fargate/service'
   TemplateVersion:
     Description: 'cloudonaut.io template version.'
     Value: '__VERSION__'

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -319,7 +319,6 @@ Resources:
         ServiceSecurityGroup: !Ref ServiceSecurityGroup
         ParentClusterStack: !Ref ParentClusterStack
         ParentAlertStack: !Ref ParentAlertStack
-        ParentClientStack: !Ref ParentClientStack
         ParentClientStack1: !Ref ParentClientStack1
         ParentClientStack2: !Ref ParentClientStack2
         ParentClientStack3: !Ref ParentClientStack3

--- a/fargate/service-cluster-alb.yaml
+++ b/fargate/service-cluster-alb.yaml
@@ -312,107 +312,13 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
-Mappings:
-  CpuMap:
-    '0.25':
-      Cpu: 256
-    '0.5':
-      Cpu: 512
-    '1':
-      Cpu: 1024
-    '2':
-      Cpu: 2048
-    '4':
-      Cpu: 4096
-  MemoryMap:
-    '0.5':
-      Memory: 512
-    '1':
-      Memory: 1024
-    '2':
-      Memory: 2048
-    '3':
-      Memory: 3072
-    '4':
-      Memory: 4096
-    '5':
-      Memory: 5120
-    '6':
-      Memory: 6144
-    '7':
-      Memory: 7168
-    '8':
-      Memory: 8192
-    '9':
-      Memory: 9216
-    '10':
-      Memory: 10240
-    '11':
-      Memory: 11264
-    '12':
-      Memory: 12288
-    '13':
-      Memory: 13312
-    '14':
-      Memory: 14336
-    '15':
-      Memory: 15360
-    '16':
-      Memory: 16384
-    '17':
-      Memory: 17408
-    '18':
-      Memory: 18432
-    '19':
-      Memory: 19456
-    '20':
-      Memory: 20480
-    '21':
-      Memory: 21504
-    '22':
-      Memory: 22528
-    '23':
-      Memory: 23552
-    '24':
-      Memory: 24576
-    '25':
-      Memory: 25600
-    '26':
-      Memory: 26624
-    '27':
-      Memory: 27648
-    '28':
-      Memory: 28672
-    '29':
-      Memory: 29696
-    '30':
-      Memory: 30720
 Conditions:
   HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
   HasLoadBalancerPathPattern: !Not [!Equals [!Ref LoadBalancerPathPattern, '']]
   HasLoadBalancerHostPattern: !Not [!Equals [!Ref LoadBalancerHostPattern, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
-  HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
-  HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
-  HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
-  HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
-  HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
-  HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
-  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
-  HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
-  HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
-  HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
   HasProxyImage: !Not [!Equals [!Ref ProxyImage, '']]
-  HasProxyCommand: !Not [!Equals [!Ref ProxyCommand, '']]
-  HasProxyEnvironment1Key: !Not [!Equals [!Ref ProxyEnvironment1Key, '']]
-  HasProxyEnvironment2Key: !Not [!Equals [!Ref ProxyEnvironment2Key, '']]
-  HasProxyEnvironment3Key: !Not [!Equals [!Ref ProxyEnvironment3Key, '']]
-  HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
-  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
-  HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
-  HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
-  HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
 Resources:
   RecordSet:
     Condition: HasZone
@@ -512,113 +418,6 @@ Resources:
         - [] # neither LoadBalancerHostPattern nor LoadBalancerPathPattern specified
       ListenerArn: !If [HasLoadBalancerHttps, {'Fn::ImportValue': !Sub '${ParentClusterStack}-HttpsListener'}, {'Fn::ImportValue': !Sub '${ParentClusterStack}-HttpListener'}]
       Priority: !Ref LoadBalancerPriority
-  TaskExecutionRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'ecs-tasks.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: AmazonECSTaskExecutionRolePolicy # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'ecr:GetAuthorizationToken'
-            - 'ecr:BatchCheckLayerAvailability'
-            - 'ecr:GetDownloadUrlForLayer'
-            - 'ecr:BatchGetImage'
-            Resource: '*'
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LogGroup.Arn'
-  TaskRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'ecs-tasks.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      ManagedPolicyArns: !If [HasTaskPolicies, !Split [',', !Ref TaskPolicies], !Ref 'AWS::NoValue']
-  TaskDefinition:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      ContainerDefinitions:
-      - !If
-        - HasProxyImage
-        - Name: proxy
-          Image: !Ref ProxyImage
-          Command: !If [HasProxyCommand, !Ref ProxyCommand, !Ref 'AWS::NoValue']
-          PortMappings:
-          - ContainerPort: !Ref ProxyPort
-            Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              'awslogs-region': !Ref 'AWS::Region'
-              'awslogs-group': !Ref LogGroup
-              'awslogs-stream-prefix': proxy
-          Environment:
-          - !If [HasProxyEnvironment1Key, {Name: !Ref ProxyEnvironment1Key, Value: !Ref ProxyEnvironment1Value}, !Ref 'AWS::NoValue']
-          - !If [HasProxyEnvironment2Key, {Name: !Ref ProxyEnvironment2Key, Value: !Ref ProxyEnvironment2Value}, !Ref 'AWS::NoValue']
-          - !If [HasProxyEnvironment3Key, {Name: !Ref ProxyEnvironment3Key, Value: !Ref ProxyEnvironment3Value}, !Ref 'AWS::NoValue']
-        - !Ref 'AWS::NoValue'
-      - Name: app
-        Image: !Ref AppImage
-        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
-        PortMappings:
-        - ContainerPort: !Ref AppPort
-          Protocol: tcp
-        Essential: true
-        LogConfiguration:
-          LogDriver: awslogs
-          Options:
-            'awslogs-region': !Ref 'AWS::Region'
-            'awslogs-group': !Ref LogGroup
-            'awslogs-stream-prefix': app
-        Environment:
-        - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
-        - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
-        - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
-      - !If
-        - HasSidecarImage
-        - Name: sidecar
-          Image: !Ref SidecarImage
-          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
-          PortMappings:
-          - ContainerPort: !Ref SidecarPort
-            Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              'awslogs-region': !Ref 'AWS::Region'
-              'awslogs-group': !Ref LogGroup
-              'awslogs-stream-prefix': sidecar
-          Environment:
-          - !If [HasSidecarEnvironment1Key, {Name: !Ref SidecarEnvironment1Key, Value: !Ref SidecarEnvironment1Value}, !Ref 'AWS::NoValue']
-          - !If [HasSidecarEnvironment2Key, {Name: !Ref SidecarEnvironment2Key, Value: !Ref SidecarEnvironment2Value}, !Ref 'AWS::NoValue']
-          - !If [HasSidecarEnvironment3Key, {Name: !Ref SidecarEnvironment3Key, Value: !Ref SidecarEnvironment3Value}, !Ref 'AWS::NoValue']
-        - !Ref 'AWS::NoValue'
-      Cpu: !FindInMap [CpuMap, !Ref Cpu, Cpu]
-      ExecutionRoleArn: !GetAtt 'TaskExecutionRole.Arn'
-      Family: !Ref 'AWS::StackName'
-      Memory: !FindInMap [MemoryMap, !Ref Memory, Memory]
-      NetworkMode: awsvpc
-      RequiresCompatibilities: [FARGATE]
-      TaskRoleArn: !GetAtt 'TaskRole.Arn'
-  LogGroup:
-    Type: 'AWS::Logs::LogGroup'
-    Properties:
-      RetentionInDays: !Ref LogsRetentionInDays
   ServiceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -631,156 +430,55 @@ Resources:
         IpProtocol: tcp
   Service:
     DependsOn: LoadBalancerListenerRule
-    Type: 'AWS::ECS::Service'
+    Type: 'AWS::CloudFormation::Stack'
     Properties:
-      Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      DeploymentConfiguration:
-        MaximumPercent: 200
-        MinimumHealthyPercent: 100
-      DesiredCount: !Ref DesiredCount
-      HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
-      LaunchType: FARGATE
-      LoadBalancers:
-      - ContainerName: !If [HasProxyImage, proxy, app]
-        ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
-        TargetGroupArn: !Ref TargetGroup
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: !If [HasSubnetsReachPublic, ENABLED, DISABLED]
-          SecurityGroups:
-          - !Ref ServiceSecurityGroup
-          - !If [HasClientSecurityGroup1, {'Fn::ImportValue': !Sub '${ParentClientStack1}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          - !If [HasClientSecurityGroup2, {'Fn::ImportValue': !Sub '${ParentClientStack2}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          - !If [HasClientSecurityGroup3, {'Fn::ImportValue': !Sub '${ParentClientStack3}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          Subnets: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-Subnets${SubnetsReach}'}]
-      TaskDefinition: !Ref TaskDefinition
-  CPUUtilizationTooHighAlarm:
-    Condition: HasAlertTopic
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Average CPU utilization over last 10 minutes higher than 80%'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 80
-      AlarmActions:
-      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
-  ScalableTargetRole: # based on http://docs.aws.amazon.com/AmazonECS/latest/developerguide/autoscale_IAM_role.html
-    Condition: HasAutoScaling
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'application-autoscaling.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: AmazonEC2ContainerServiceAutoscaleRole
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'ecs:DescribeServices'
-            - 'ecs:UpdateService'
-            Resource: '*'
-      - PolicyName: cloudwatch
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'cloudwatch:DescribeAlarms'
-            Resource: '*'
-  ScalableTarget:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
-    Properties:
-      MaxCapacity: !Ref MaxCapacity
-      MinCapacity: !Ref MinCapacity
-      ResourceId: !Sub
-      - 'service/${Cluster}/${Service}'
-      - Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-        Service: !GetAtt 'Service.Name'
-      RoleARN: !GetAtt 'ScalableTargetRole.Arn'
-      ScalableDimension: 'ecs:service:DesiredCount'
-      ServiceNamespace: ecs
-  ScaleUpPolicy:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
-    Properties:
-      PolicyName: !Sub '${AWS::StackName}-scale-up'
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref ScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 300
-        MinAdjustmentMagnitude: 1
-        StepAdjustments:
-        - MetricIntervalLowerBound: 0
-          ScalingAdjustment: 25
-  ScaleDownPolicy:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
-    Properties:
-      PolicyName: !Sub '${AWS::StackName}-scale-down'
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref ScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 300
-        MinAdjustmentMagnitude: 1
-        StepAdjustments:
-        - MetricIntervalUpperBound: 0
-          ScalingAdjustment: -25
-  CPUUtilizationHighAlarm:
-    Condition: HasAutoScaling
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Service is running out of CPU'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 60
-      AlarmActions:
-      - !Ref ScaleUpPolicy
-  CPUUtilizationLowAlarm:
-    Condition: HasAutoScaling
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Service is wasting CPU'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: LessThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 3
-      Threshold: 30
-      AlarmActions:
-      - !Ref ScaleDownPolicy
+      Parameters:
+        LoadBalancerTargetGroup: !Ref TargetGroup
+        ServiceSecurityGroup: !Ref ServiceSecurityGroup
+        ParentVPCStack: !Ref ParentVPCStack
+        ParentClusterStack: !Ref ParentClusterStack
+        ParentAlertStack: !Ref ParentAlertStack
+        ParentClientStack1: !Ref ParentClientStack1
+        ParentClientStack2: !Ref ParentClientStack2
+        ParentClientStack3: !Ref ParentClientStack3
+        TaskPolicies: !Ref TaskPolicies
+        ProxyImage: !Ref ProxyImage
+        ProxyCommand: !Ref ProxyCommand
+        ProxyPort: !Ref ProxyPort
+        ProxyEnvironment1Key: !Ref ProxyEnvironment1Key
+        ProxyEnvironment1Value: !Ref ProxyEnvironment1Value
+        ProxyEnvironment2Key: !Ref ProxyEnvironment2Key
+        ProxyEnvironment2Value: !Ref ProxyEnvironment2Value
+        ProxyEnvironment3Key: !Ref ProxyEnvironment3Key
+        ProxyEnvironment3Value: !Ref ProxyEnvironment3Value
+        AppImage: !Ref AppImage
+        AppCommand: !Ref AppCommand
+        AppPort: !Ref AppPort
+        AppEnvironment1Key: !Ref AppEnvironment1Key
+        AppEnvironment1Value: !Ref AppEnvironment1Value
+        AppEnvironment2Key: !Ref AppEnvironment2Key
+        AppEnvironment2Value: !Ref AppEnvironment2Value
+        AppEnvironment3Key: !Ref AppEnvironment3Key
+        AppEnvironment3Value: !Ref AppEnvironment3Value
+        SidecarImage: !Ref SidecarImage
+        SidecarCommand: !Ref SidecarCommand
+        SidecarPort: !Ref SidecarPort
+        SidecarEnvironment1Key: !Ref SidecarEnvironment1Key
+        SidecarEnvironment1Value: !Ref SidecarEnvironment1Value
+        SidecarEnvironment2Key: !Ref SidecarEnvironment2Key
+        SidecarEnvironment2Value: !Ref SidecarEnvironment2Value
+        SidecarEnvironment3Key: !Ref SidecarEnvironment3Key
+        SidecarEnvironment3Value: !Ref SidecarEnvironment3Value
+        Cpu: !Ref Cpu
+        Memory: !Ref Memory
+        SubnetsReach: !Ref SubnetsReach
+        AutoScaling: !Ref AutoScaling
+        DesiredCount: !Ref DesiredCount
+        MaxCapacity: !Ref MaxCapacity
+        MinCapacity: !Ref MinCapacity
+        HealthCheckGracePeriod: !Ref HealthCheckGracePeriod
+        LogsRetentionInDays: !Ref LogsRetentionInDays
+      TemplateURL: './aws-cf-templates/fargate/service-cloudmap.yaml'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/fargate/service-dedicated-alb.yaml
+++ b/fargate/service-dedicated-alb.yaml
@@ -312,81 +312,6 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
-Mappings:
-  CpuMap:
-    '0.25':
-      Cpu: 256
-    '0.5':
-      Cpu: 512
-    '1':
-      Cpu: 1024
-    '2':
-      Cpu: 2048
-    '4':
-      Cpu: 4096
-  MemoryMap:
-    '0.5':
-      Memory: 512
-    '1':
-      Memory: 1024
-    '2':
-      Memory: 2048
-    '3':
-      Memory: 3072
-    '4':
-      Memory: 4096
-    '5':
-      Memory: 5120
-    '6':
-      Memory: 6144
-    '7':
-      Memory: 7168
-    '8':
-      Memory: 8192
-    '9':
-      Memory: 9216
-    '10':
-      Memory: 10240
-    '11':
-      Memory: 11264
-    '12':
-      Memory: 12288
-    '13':
-      Memory: 13312
-    '14':
-      Memory: 14336
-    '15':
-      Memory: 15360
-    '16':
-      Memory: 16384
-    '17':
-      Memory: 17408
-    '18':
-      Memory: 18432
-    '19':
-      Memory: 19456
-    '20':
-      Memory: 20480
-    '21':
-      Memory: 21504
-    '22':
-      Memory: 22528
-    '23':
-      Memory: 23552
-    '24':
-      Memory: 24576
-    '25':
-      Memory: 25600
-    '26':
-      Memory: 26624
-    '27':
-      Memory: 27648
-    '28':
-      Memory: 28672
-    '29':
-      Memory: 29696
-    '30':
-      Memory: 30720
 Conditions:
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
   HasNotAuthProxySecurityGroup: !Equals [!Ref ParentAuthProxyStack, '']
@@ -397,26 +322,6 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
-  HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
-  HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
-  HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
-  HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
-  HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
-  HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
-  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
-  HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
-  HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
-  HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
-  HasProxyImage: !Not [!Equals [!Ref ProxyImage, '']]
-  HasProxyCommand: !Not [!Equals [!Ref ProxyCommand, '']]
-  HasProxyEnvironment1Key: !Not [!Equals [!Ref ProxyEnvironment1Key, '']]
-  HasProxyEnvironment2Key: !Not [!Equals [!Ref ProxyEnvironment2Key, '']]
-  HasProxyEnvironment3Key: !Not [!Equals [!Ref ProxyEnvironment3Key, '']]
-  HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
-  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
-  HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
-  HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
-  HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
 Resources:
   RecordSet:
     Condition: HasZone
@@ -614,113 +519,6 @@ Resources:
       - Name: TargetGroup
         Value: !GetAtt TargetGroup.TargetGroupFullName
       TreatMissingData: notBreaching
-  TaskExecutionRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'ecs-tasks.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: AmazonECSTaskExecutionRolePolicy # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
-        PolicyDocument:
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'ecr:GetAuthorizationToken'
-            - 'ecr:BatchCheckLayerAvailability'
-            - 'ecr:GetDownloadUrlForLayer'
-            - 'ecr:BatchGetImage'
-            Resource: '*'
-          - Effect: Allow
-            Action:
-            - 'logs:CreateLogStream'
-            - 'logs:PutLogEvents'
-            Resource: !GetAtt 'LogGroup.Arn'
-  TaskRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'ecs-tasks.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      ManagedPolicyArns: !If [HasTaskPolicies, !Split [',', !Ref TaskPolicies], !Ref 'AWS::NoValue']
-  TaskDefinition:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      ContainerDefinitions:
-      - !If
-        - HasProxyImage
-        - Name: proxy
-          Image: !Ref ProxyImage
-          Command: !If [HasProxyCommand, !Ref ProxyCommand, !Ref 'AWS::NoValue']
-          PortMappings:
-          - ContainerPort: !Ref ProxyPort
-            Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              'awslogs-region': !Ref 'AWS::Region'
-              'awslogs-group': !Ref LogGroup
-              'awslogs-stream-prefix': proxy
-          Environment:
-          - !If [HasProxyEnvironment1Key, {Name: !Ref ProxyEnvironment1Key, Value: !Ref ProxyEnvironment1Value}, !Ref 'AWS::NoValue']
-          - !If [HasProxyEnvironment2Key, {Name: !Ref ProxyEnvironment2Key, Value: !Ref ProxyEnvironment2Value}, !Ref 'AWS::NoValue']
-          - !If [HasProxyEnvironment3Key, {Name: !Ref ProxyEnvironment3Key, Value: !Ref ProxyEnvironment3Value}, !Ref 'AWS::NoValue']
-        - !Ref 'AWS::NoValue'
-      - Name: app
-        Image: !Ref AppImage
-        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
-        PortMappings:
-        - ContainerPort: !Ref AppPort
-          Protocol: tcp
-        Essential: true
-        LogConfiguration:
-          LogDriver: awslogs
-          Options:
-            'awslogs-region': !Ref 'AWS::Region'
-            'awslogs-group': !Ref LogGroup
-            'awslogs-stream-prefix': app
-        Environment:
-        - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
-        - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
-        - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
-      - !If
-        - HasSidecarImage
-        - Name: sidecar
-          Image: !Ref SidecarImage
-          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
-          PortMappings:
-          - ContainerPort: !Ref SidecarPort
-            Protocol: tcp
-          Essential: true
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              'awslogs-region': !Ref 'AWS::Region'
-              'awslogs-group': !Ref LogGroup
-              'awslogs-stream-prefix': sidecar
-          Environment:
-          - !If [HasSidecarEnvironment1Key, {Name: !Ref SidecarEnvironment1Key, Value: !Ref SidecarEnvironment1Value}, !Ref 'AWS::NoValue']
-          - !If [HasSidecarEnvironment2Key, {Name: !Ref SidecarEnvironment2Key, Value: !Ref SidecarEnvironment2Value}, !Ref 'AWS::NoValue']
-          - !If [HasSidecarEnvironment3Key, {Name: !Ref SidecarEnvironment3Key, Value: !Ref SidecarEnvironment3Value}, !Ref 'AWS::NoValue']
-        - !Ref 'AWS::NoValue'
-      Cpu: !FindInMap [CpuMap, !Ref Cpu, Cpu]
-      ExecutionRoleArn: !GetAtt 'TaskExecutionRole.Arn'
-      Family: !Ref 'AWS::StackName'
-      Memory: !FindInMap [MemoryMap, !Ref Memory, Memory]
-      NetworkMode: awsvpc
-      RequiresCompatibilities: [FARGATE]
-      TaskRoleArn: !GetAtt 'TaskRole.Arn'
-  LogGroup:
-    Type: 'AWS::Logs::LogGroup'
-    Properties:
-      RetentionInDays: !Ref LogsRetentionInDays
   ServiceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -732,157 +530,56 @@ Resources:
         ToPort: 65535
         IpProtocol: tcp
   Service:
-    Type: 'AWS::ECS::Service'
     DependsOn: HttpListener
+    Type: 'AWS::CloudFormation::Stack'
     Properties:
-      Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      DeploymentConfiguration:
-        MaximumPercent: 200
-        MinimumHealthyPercent: 100
-      DesiredCount: !Ref DesiredCount
-      HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
-      LaunchType: FARGATE
-      LoadBalancers:
-      - ContainerName: !If [HasProxyImage, proxy, app]
-        ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
-        TargetGroupArn: !Ref TargetGroup
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: !If [HasSubnetsReachPublic, ENABLED, DISABLED]
-          SecurityGroups:
-          - !Ref ServiceSecurityGroup
-          - !If [HasClientSecurityGroup1, {'Fn::ImportValue': !Sub '${ParentClientStack1}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          - !If [HasClientSecurityGroup2, {'Fn::ImportValue': !Sub '${ParentClientStack2}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          - !If [HasClientSecurityGroup3, {'Fn::ImportValue': !Sub '${ParentClientStack3}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
-          Subnets: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-Subnets${SubnetsReach}'}]
-      TaskDefinition: !Ref TaskDefinition
-  CPUUtilizationTooHighAlarm:
-    Condition: HasAlertTopic
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Average CPU utilization over last 10 minutes higher than 80%'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 80
-      AlarmActions:
-      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
-  ScalableTargetRole: # based on http://docs.aws.amazon.com/AmazonECS/latest/developerguide/autoscale_IAM_role.html
-    Condition: HasAutoScaling
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: 'application-autoscaling.amazonaws.com'
-          Action: 'sts:AssumeRole'
-      Policies:
-      - PolicyName: AmazonEC2ContainerServiceAutoscaleRole
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'ecs:DescribeServices'
-            - 'ecs:UpdateService'
-            Resource: '*'
-      - PolicyName: cloudwatch
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - 'cloudwatch:DescribeAlarms'
-            Resource: '*'
-  ScalableTarget:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
-    Properties:
-      MaxCapacity: !Ref MaxCapacity
-      MinCapacity: !Ref MinCapacity
-      ResourceId: !Sub
-      - 'service/${Cluster}/${Service}'
-      - Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-        Service: !GetAtt 'Service.Name'
-      RoleARN: !GetAtt 'ScalableTargetRole.Arn'
-      ScalableDimension: 'ecs:service:DesiredCount'
-      ServiceNamespace: ecs
-  ScaleUpPolicy:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
-    Properties:
-      PolicyName: !Sub '${AWS::StackName}-scale-up'
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref ScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 300
-        MinAdjustmentMagnitude: 1
-        StepAdjustments:
-        - MetricIntervalLowerBound: 0
-          ScalingAdjustment: 25
-  ScaleDownPolicy:
-    Condition: HasAutoScaling
-    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
-    Properties:
-      PolicyName: !Sub '${AWS::StackName}-scale-down'
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref ScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 300
-        MinAdjustmentMagnitude: 1
-        StepAdjustments:
-        - MetricIntervalUpperBound: 0
-          ScalingAdjustment: -25
-  CPUUtilizationHighAlarm:
-    Condition: HasAutoScaling
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Service is running out of CPU'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: GreaterThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 1
-      Threshold: 60
-      AlarmActions:
-      - !Ref ScaleUpPolicy
-  CPUUtilizationLowAlarm:
-    Condition: HasAutoScaling
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmDescription: 'Service is wasting CPU'
-      Namespace: 'AWS/ECS'
-      Dimensions:
-      - Name: ClusterName
-        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
-      - Name: ServiceName
-        Value: !GetAtt 'Service.Name'
-      MetricName: CPUUtilization
-      ComparisonOperator: LessThanThreshold
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 3
-      Threshold: 30
-      AlarmActions:
-      - !Ref ScaleDownPolicy
+      Parameters:
+        LoadBalancerTargetGroup: !Ref TargetGroup
+        ServiceSecurityGroup: !Ref ServiceSecurityGroup
+        ParentVPCStack: !Ref ParentVPCStack
+        ParentClusterStack: !Ref ParentClusterStack
+        ParentAlertStack: !Ref ParentAlertStack
+        ParentClientStack1: !Ref ParentClientStack1
+        ParentClientStack2: !Ref ParentClientStack2
+        ParentClientStack3: !Ref ParentClientStack3
+        TaskPolicies: !Ref TaskPolicies
+        ProxyImage: !Ref ProxyImage
+        ProxyCommand: !Ref ProxyCommand
+        ProxyPort: !Ref ProxyPort
+        ProxyEnvironment1Key: !Ref ProxyEnvironment1Key
+        ProxyEnvironment1Value: !Ref ProxyEnvironment1Value
+        ProxyEnvironment2Key: !Ref ProxyEnvironment2Key
+        ProxyEnvironment2Value: !Ref ProxyEnvironment2Value
+        ProxyEnvironment3Key: !Ref ProxyEnvironment3Key
+        ProxyEnvironment3Value: !Ref ProxyEnvironment3Value
+        AppImage: !Ref AppImage
+        AppCommand: !Ref AppCommand
+        AppPort: !Ref AppPort
+        AppEnvironment1Key: !Ref AppEnvironment1Key
+        AppEnvironment1Value: !Ref AppEnvironment1Value
+        AppEnvironment2Key: !Ref AppEnvironment2Key
+        AppEnvironment2Value: !Ref AppEnvironment2Value
+        AppEnvironment3Key: !Ref AppEnvironment3Key
+        AppEnvironment3Value: !Ref AppEnvironment3Value
+        SidecarImage: !Ref SidecarImage
+        SidecarCommand: !Ref SidecarCommand
+        SidecarPort: !Ref SidecarPort
+        SidecarEnvironment1Key: !Ref SidecarEnvironment1Key
+        SidecarEnvironment1Value: !Ref SidecarEnvironment1Value
+        SidecarEnvironment2Key: !Ref SidecarEnvironment2Key
+        SidecarEnvironment2Value: !Ref SidecarEnvironment2Value
+        SidecarEnvironment3Key: !Ref SidecarEnvironment3Key
+        SidecarEnvironment3Value: !Ref SidecarEnvironment3Value
+        Cpu: !Ref Cpu
+        Memory: !Ref Memory
+        SubnetsReach: !Ref SubnetsReach
+        AutoScaling: !Ref AutoScaling
+        DesiredCount: !Ref DesiredCount
+        MaxCapacity: !Ref MaxCapacity
+        MinCapacity: !Ref MinCapacity
+        HealthCheckGracePeriod: !Ref HealthCheckGracePeriod
+        LogsRetentionInDays: !Ref LogsRetentionInDays
+      TemplateURL: './aws-cf-templates/fargate/service-cloudmap.yaml'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/fargate/service.yaml
+++ b/fargate/service.yaml
@@ -1,0 +1,677 @@
+---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Fargate: service that runs on a Fargate cluster based on fargate/cluster.yaml with service discovery via Cloud Map, a cloudonaut.io template'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentVPCStack
+      - ParentClusterStack
+      - ParentAlertStack
+      - ParentClientStack1
+      - ParentClientStack2
+      - ParentClientStack3
+    - Label:
+        default: 'Service Parameters'
+      Parameters:
+      - ServiceDiscoveryARN
+      - LoadBalancerTargetGroup
+      - ServiceSecurityGroup
+    - Label:
+        default: 'Task Parameters'
+      Parameters:
+      - TaskPolicies
+      - ProxyImage
+      - ProxyCommand
+      - ProxyPort
+      - ProxyEnvironment1Key
+      - ProxyEnvironment1Value
+      - ProxyEnvironment2Key
+      - ProxyEnvironment2Value
+      - ProxyEnvironment3Key
+      - ProxyEnvironment3Value
+      - AppImage
+      - AppCommand
+      - AppPort
+      - AppEnvironment1Key
+      - AppEnvironment1Value
+      - AppEnvironment2Key
+      - AppEnvironment2Value
+      - AppEnvironment3Key
+      - AppEnvironment3Value
+      - SidecarImage
+      - SidecarCommand
+      - SidecarPort
+      - SidecarEnvironment1Key
+      - SidecarEnvironment1Value
+      - SidecarEnvironment2Key
+      - SidecarEnvironment2Value
+      - SidecarEnvironment3Key
+      - SidecarEnvironment3Value
+    - Label:
+        default: 'Service Parameters'
+      Parameters:
+      - Cpu
+      - Memory
+      - SubnetsReach
+      - AutoScaling
+      - DesiredCount
+      - MaxCapacity
+      - MinCapacity
+      - HealthCheckGracePeriod
+      - LogsRetentionInDays
+Parameters:
+  ServiceDiscoveryARN:
+    Description: 'ARN of AWS::ServiceDiscovery::Service to link service to CloudMap'
+    Type: String
+    Default: ''
+  LoadBalancerTargetGroup:
+    Description: 'Ref to AWS::ElasticLoadBalancingV2::TargetGroup to link service to ALB'
+    Type: String
+    Default: ''
+  ServiceSecurityGroup:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentVPCStack:
+    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Type: String
+  ParentClusterStack:
+    Description: 'Stack name of parent Cluster stack based on fargate/cluster.yaml template.'
+    Type: String
+  ParentAlertStack:
+    Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
+    Type: String
+    Default: ''
+  ParentClientStack1:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentClientStack2:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentClientStack3:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  TaskPolicies:
+    Description: 'Comma-delimited list of IAM managed policy ARNs to attach to the task IAM role'
+    Type: String
+    Default: ''
+  ProxyImage:
+    Description: 'Optional Docker image to use for the proxy container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  ProxyCommand:
+    Description: 'Optional command used when starting the proxy container.'
+    Type: String
+    Default: ''
+  ProxyPort:
+    Description: 'The port exposed by the proxy container that receives traffic from the load balancer (ProxyPort <> AppPort <> SidecarPort; ignored if ProxyImage is not set).'
+    Type: Number
+    # zero is not a valid port and indicates no port was provided
+    Default: 0
+    MinValue: 0
+    MaxValue: 49150
+  ProxyEnvironment1Key:
+    Description: 'Optional environment variable 1 key for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment1Value:
+    Description: 'Optional environment variable 1 value for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment2Key:
+    Description: 'Optional environment variable 2 key for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment2Value:
+    Description: 'Optional environment variable 2 value for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment3Key:
+    Description: 'Optional environment variable 3 key for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment3Value:
+    Description: 'Optional environment variable 3 value for proxy container.'
+    Type: String
+    Default: ''
+  AppImage:
+    Description: 'The Docker image to use for the app container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: 'widdix/hello:v1'
+  AppCommand:
+    Description: 'Optional commands (comma-delimited) used when starting the app container.'
+    Type: String
+    Default: ''
+  AppPort:
+    Description: 'The port exposed by the app container that receives traffic from the load balancer or the proxy container (AppPort <> ProxyPort <> SidecarPort).'
+    Type: Number
+    # zero is not a valid port and indicates no port was provided
+    Default: 0
+    MinValue: 0
+    MaxValue: 49150
+  AppEnvironment1Key:
+    Description: 'Optional environment variable 1 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment1Value:
+    Description: 'Optional environment variable 1 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment2Key:
+    Description: 'Optional environment variable 2 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment2Value:
+    Description: 'Optional environment variable 2 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment3Key:
+    Description: 'Optional environment variable 3 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment3Value:
+    Description: 'Optional environment variable 3 value for app container.'
+    Type: String
+    Default: ''
+  SidecarImage:
+    Description: 'Optional Docker image to use for the sidecar container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  SidecarCommand:
+    Description: 'Optional command used when starting the sidecar container.'
+    Type: String
+    Default: ''
+  SidecarPort:
+    Description: 'The port exposed by the sidecar container reachable from the app container on host localhost (SidecarPort <> ProxyPort <> AppPort).'
+    Type: Number
+    # zero is not a valid port and indicates no port was provided
+    Default: 0
+    MinValue: 0
+    MaxValue: 49150
+  SidecarEnvironment1Key:
+    Description: 'Optional environment variable 1 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment1Value:
+    Description: 'Optional environment variable 1 value for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment2Key:
+    Description: 'Optional environment variable 2 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment2Value:
+    Description: 'Optional environment variable 2 value for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment3Key:
+    Description: 'Optional environment variable 3 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment3Value:
+    Description: 'Optional environment variable 3 value for sidecar container.'
+    Type: String
+    Default: ''
+  Cpu:
+    Description: 'The minimum number of vCPUs to reserve for the container.'
+    Type: String
+    Default: '0.25'
+    AllowedValues: ['0.25', '0.5', '1', '2', '4']
+  Memory:
+    Description: 'The amount (in GB) of memory used by the task.'
+    Type: String
+    Default: '0.5'
+    AllowedValues: ['0.5', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30']
+  DesiredCount:
+    Description: 'The number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 2
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  MaxCapacity:
+    Description: 'The maximum number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 4
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  MinCapacity:
+    Description: 'The minimum number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 2
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  LogsRetentionInDays:
+    Description: 'Specifies the number of days you want to retain log events in the specified log group.'
+    Type: Number
+    Default: 14
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  SubnetsReach:
+    Description: 'Should the service have direct access to the Internet or do you prefer private subnets with NAT?'
+    Type: String
+    Default: Public
+    AllowedValues:
+    - Public
+    - Private
+  AutoScaling:
+    Description: 'Scale number of tasks based on CPU load?'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+  HealthCheckGracePeriod:
+    Description: 'The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started.'
+    Type: Number
+    # invalid value functions as empty
+    Default: -1
+    MinValue: -1
+    MaxValue: 1800
+Mappings:
+  CpuMap:
+    '0.25':
+      Cpu: 256
+    '0.5':
+      Cpu: 512
+    '1':
+      Cpu: 1024
+    '2':
+      Cpu: 2048
+    '4':
+      Cpu: 4096
+  MemoryMap:
+    '0.5':
+      Memory: 512
+    '1':
+      Memory: 1024
+    '2':
+      Memory: 2048
+    '3':
+      Memory: 3072
+    '4':
+      Memory: 4096
+    '5':
+      Memory: 5120
+    '6':
+      Memory: 6144
+    '7':
+      Memory: 7168
+    '8':
+      Memory: 8192
+    '9':
+      Memory: 9216
+    '10':
+      Memory: 10240
+    '11':
+      Memory: 11264
+    '12':
+      Memory: 12288
+    '13':
+      Memory: 13312
+    '14':
+      Memory: 14336
+    '15':
+      Memory: 15360
+    '16':
+      Memory: 16384
+    '17':
+      Memory: 17408
+    '18':
+      Memory: 18432
+    '19':
+      Memory: 19456
+    '20':
+      Memory: 20480
+    '21':
+      Memory: 21504
+    '22':
+      Memory: 22528
+    '23':
+      Memory: 23552
+    '24':
+      Memory: 24576
+    '25':
+      Memory: 25600
+    '26':
+      Memory: 26624
+    '27':
+      Memory: 27648
+    '28':
+      Memory: 28672
+    '29':
+      Memory: 29696
+    '30':
+      Memory: 30720
+Conditions:
+  HasServiceDiscovery: !Not [!Equals [!Ref ServiceDiscoveryARN, '']]
+  HasLoadBalancer: !Not [!Equals [!Ref LoadBalancerTargetGroup, '']]
+  HasHealthCheckGracePeriod: !Not [!Equals [!Ref HealthCheckGracePeriod, -1]]
+  HasServiceSecurityGroup: !Not [!Equals [!Ref ServiceSecurityGroup, '']]
+  HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
+  HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
+  HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
+  HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
+  HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
+  HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
+  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
+  HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
+  HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
+  HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
+  HasProxyImage: !Not [!Equals [!Ref ProxyImage, '']]
+  HasProxyCommand: !Not [!Equals [!Ref ProxyCommand, '']]
+  HasProxyEnvironment1Key: !Not [!Equals [!Ref ProxyEnvironment1Key, '']]
+  HasProxyEnvironment2Key: !Not [!Equals [!Ref ProxyEnvironment2Key, '']]
+  HasProxyEnvironment3Key: !Not [!Equals [!Ref ProxyEnvironment3Key, '']]
+  HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
+  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
+  HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
+  HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
+  HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
+  HasAppPort: !Not [!Equals [!Ref AppPort, 0]]
+  HasProxyPort: !And [!Condition HasProxyImage, !Not [!Equals [!Ref ProxyPort, 0]]]
+  HasSidecarPort: !And [!Condition HasSidecarImage, !Not [!Equals [!Ref SidecarPort, 0]]]
+Resources:
+  TaskExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'ecs-tasks.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: AmazonECSTaskExecutionRolePolicy # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ecr:GetAuthorizationToken'
+            - 'ecr:BatchCheckLayerAvailability'
+            - 'ecr:GetDownloadUrlForLayer'
+            - 'ecr:BatchGetImage'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LogGroup.Arn'
+  TaskRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'ecs-tasks.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasTaskPolicies, !Split [',', !Ref TaskPolicies], !Ref 'AWS::NoValue']
+  TaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+      - !If
+        - HasProxyImage
+        - Name: proxy
+          Image: !Ref ProxyImage
+          Command: !If [HasProxyCommand, !Ref ProxyCommand, !Ref 'AWS::NoValue']
+          PortMappings:
+          - !If
+            - HasProxyPort
+            - ContainerPort: !Ref ProxyPort
+              Protocol: tcp
+            - !Ref 'AWS::NoValue'
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              'awslogs-region': !Ref 'AWS::Region'
+              'awslogs-group': !Ref LogGroup
+              'awslogs-stream-prefix': proxy
+          Environment:
+          - !If [HasProxyEnvironment1Key, {Name: !Ref ProxyEnvironment1Key, Value: !Ref ProxyEnvironment1Value}, !Ref 'AWS::NoValue']
+          - !If [HasProxyEnvironment2Key, {Name: !Ref ProxyEnvironment2Key, Value: !Ref ProxyEnvironment2Value}, !Ref 'AWS::NoValue']
+          - !If [HasProxyEnvironment3Key, {Name: !Ref ProxyEnvironment3Key, Value: !Ref ProxyEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !Ref 'AWS::NoValue'
+      - Name: app
+        Image: !Ref AppImage
+        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
+        PortMappings:
+        - !If
+          - HasAppPort
+          - ContainerPort: !Ref AppPort
+            Protocol: tcp
+          - !Ref 'AWS::NoValue'
+        Essential: true
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            'awslogs-region': !Ref 'AWS::Region'
+            'awslogs-group': !Ref LogGroup
+            'awslogs-stream-prefix': app
+        Environment:
+        - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
+      - !If
+        - HasSidecarImage
+        - Name: sidecar
+          Image: !Ref SidecarImage
+          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
+          PortMappings:
+          - !If
+            - HasSidecarPort
+            - ContainerPort: !Ref SidecarPort
+              Protocol: tcp
+            - !Ref 'AWS::NoValue'
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              'awslogs-region': !Ref 'AWS::Region'
+              'awslogs-group': !Ref LogGroup
+              'awslogs-stream-prefix': sidecar
+          Environment:
+          - !If [HasSidecarEnvironment1Key, {Name: !Ref SidecarEnvironment1Key, Value: !Ref SidecarEnvironment1Value}, !Ref 'AWS::NoValue']
+          - !If [HasSidecarEnvironment2Key, {Name: !Ref SidecarEnvironment2Key, Value: !Ref SidecarEnvironment2Value}, !Ref 'AWS::NoValue']
+          - !If [HasSidecarEnvironment3Key, {Name: !Ref SidecarEnvironment3Key, Value: !Ref SidecarEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !Ref 'AWS::NoValue'
+      Cpu: !FindInMap [CpuMap, !Ref Cpu, Cpu]
+      ExecutionRoleArn: !GetAtt 'TaskExecutionRole.Arn'
+      Family: !Ref 'AWS::StackName'
+      Memory: !FindInMap [MemoryMap, !Ref Memory, Memory]
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      TaskRoleArn: !GetAtt 'TaskRole.Arn'
+  LogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      RetentionInDays: !Ref LogsRetentionInDays
+  Service:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: !Ref DesiredCount
+      HealthCheckGracePeriodSeconds: !If [HasHealthCheckGracePeriod, !Ref HealthCheckGracePeriod, !Ref 'AWS::NoValue']
+      LaunchType: FARGATE
+      ServiceRegistries:
+      - !If
+        - HasServiceDiscovery
+        - ContainerName: !If [HasProxyImage, proxy, app]
+          ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          RegistryArn: !Ref ServiceDiscoveryARN
+        - !Ref 'AWS::NoValue'
+      LoadBalancers:
+      - !If
+        - HasLoadBalancer
+        - ContainerName: !If [HasProxyImage, proxy, app]
+          ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          TargetGroupArn: !Ref LoadBalancerTargetGroup
+        - !Ref 'AWS::NoValue'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !If [HasSubnetsReachPublic, ENABLED, DISABLED]
+          SecurityGroups:
+          - !If [HasServiceSecurityGroup, !Ref ServiceSecurityGroup, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup1, {'Fn::ImportValue': !Sub '${ParentClientStack1}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup2, {'Fn::ImportValue': !Sub '${ParentClientStack2}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup3, {'Fn::ImportValue': !Sub '${ParentClientStack3}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          Subnets: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-Subnets${SubnetsReach}'}]
+      TaskDefinition: !Ref TaskDefinition
+  CPUUtilizationTooHighAlarm:
+    Condition: HasAlertTopic
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Average CPU utilization over last 10 minutes higher than 80%'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 80
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+  ScalableTargetRole: # based on http://docs.aws.amazon.com/AmazonECS/latest/developerguide/autoscale_IAM_role.html
+    Condition: HasAutoScaling
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'application-autoscaling.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: AmazonEC2ContainerServiceAutoscaleRole
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ecs:DescribeServices'
+            - 'ecs:UpdateService'
+            Resource: '*'
+      - PolicyName: cloudwatch
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'cloudwatch:DescribeAlarms'
+            Resource: '*'
+  ScalableTarget:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    Properties:
+      MaxCapacity: !Ref MaxCapacity
+      MinCapacity: !Ref MinCapacity
+      ResourceId: !Sub
+      - 'service/${Cluster}/${Service}'
+      - Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+        Service: !GetAtt 'Service.Name'
+      RoleARN: !GetAtt 'ScalableTargetRole.Arn'
+      ScalableDimension: 'ecs:service:DesiredCount'
+      ServiceNamespace: ecs
+  ScaleUpPolicy:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: !Sub '${AWS::StackName}-scale-up'
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+        - MetricIntervalLowerBound: 0
+          ScalingAdjustment: 25
+  ScaleDownPolicy:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: !Sub '${AWS::StackName}-scale-down'
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+        - MetricIntervalUpperBound: 0
+          ScalingAdjustment: -25
+  CPUUtilizationHighAlarm:
+    Condition: HasAutoScaling
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Service is running out of CPU'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 60
+      AlarmActions:
+      - !Ref ScaleUpPolicy
+  CPUUtilizationLowAlarm:
+    Condition: HasAutoScaling
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Service is wasting CPU'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: LessThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 30
+      AlarmActions:
+      - !Ref ScaleDownPolicy
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'fargate/service'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'


### PR DESCRIPTION
I need to run Fargate services that expose no ports because they consume from queues.  Rather than proliferate `fargate/service` templates, this PR refactors the common elements of existing `fargate/service-*` templates into a common `fargate/service`.  In addition to parameters for a `LoadBalancerTargetGroup` and `ServiceDiscoveryARN` (to support existing modes), I modified it to support direct use without any sort of service discovery (i.e. providing no `AppPort`/`ProxyPort`).  To break as little validation as possible, I use the invalid port 0 as the default port and use that to indicate no service discovery.