### PR TITLE
Configurable fargate/service Template

### DIFF
--- a/fargate/cluster-alb-target.yaml
+++ b/fargate/cluster-alb-target.yaml
@@ -110,8 +110,8 @@ Resources:
       Protocol: HTTP
       TargetType: ip
       TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: !Ref LoadBalancerDeregistrationDelay
+      - Key: deregistration_delay.timeout_seconds
+        Value: !Ref LoadBalancerDeregistrationDelay
       VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
   RecordSet:
     Condition: HasZone

--- a/fargate/cluster-alb-target.yaml
+++ b/fargate/cluster-alb-target.yaml
@@ -23,7 +23,6 @@ Metadata:
       - ParentVPCStack
       - ParentClusterStack
       - ParentAlertStack
-      - ParentZoneStack
     - Label:
         default: 'Load Balancer Parameters'
       Parameters:
@@ -32,10 +31,6 @@ Metadata:
       - LoadBalancerPathPattern
       - LoadBalancerHttps
       - LoadBalancerDeregistrationDelay
-    - Label:
-        default: 'Service Parameters'
-      Parameters:
-      - SubDomainNameWithDot
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -45,10 +40,6 @@ Parameters:
     Type: String
   ParentAlertStack:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
-    Type: String
-    Default: ''
-  ParentZoneStack:
-    Description: 'Optional stack name of parent zone stack based on vpc/zone-*.yaml template.'
     Type: String
     Default: ''
   LoadBalancerPriority:
@@ -84,16 +75,11 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-3600]'
     MinValue: 0
     MaxValue: 3600
-  SubDomainNameWithDot:
-    Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
-    Type: String
-    Default: ''
 Conditions:
   HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
   HasLoadBalancerPathPattern: !Not [!Equals [!Ref LoadBalancerPathPattern, '']]
   HasLoadBalancerHostPattern: !Not [!Equals [!Ref LoadBalancerHostPattern, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
-  HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
 Resources:
   TargetGroup:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
@@ -113,19 +99,6 @@ Resources:
       - Key: deregistration_delay.timeout_seconds
         Value: !Ref LoadBalancerDeregistrationDelay
       VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
-  RecordSet:
-    Condition: HasZone
-    Type: 'AWS::Route53::RecordSet'
-    Properties:
-      AliasTarget:
-        HostedZoneId: {'Fn::ImportValue': !Sub '${ParentClusterStack}-CanonicalHostedZoneID'}
-        DNSName: {'Fn::ImportValue': !Sub '${ParentClusterStack}-DNSName'}
-      HostedZoneId: {'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneId'}
-      Name: !Sub
-      - '${SubDomainNameWithDot}${HostedZoneName}'
-      - SubDomainNameWithDot: !Ref SubDomainNameWithDot
-        HostedZoneName: {'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneName'}
-      Type: A
   HTTPCodeTarget5XXTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'

--- a/fargate/cluster-alb-target.yaml
+++ b/fargate/cluster-alb-target.yaml
@@ -1,0 +1,215 @@
+---
+# Copyright 2018 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Fargate: service that runs on a Fargate cluster based on fargate/cluster.yaml and uses the cluster ALB, a cloudonaut.io template'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentVPCStack
+      - ParentClusterStack
+      - ParentAlertStack
+      - ParentZoneStack
+    - Label:
+        default: 'Load Balancer Parameters'
+      Parameters:
+      - LoadBalancerPriority
+      - LoadBalancerHostPattern
+      - LoadBalancerPathPattern
+      - LoadBalancerHttps
+      - LoadBalancerDeregistrationDelay
+    - Label:
+        default: 'Service Parameters'
+      Parameters:
+      - SubDomainNameWithDot
+Parameters:
+  ParentVPCStack:
+    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Type: String
+  ParentClusterStack:
+    Description: 'Stack name of parent Cluster stack based on fargate/cluster.yaml template.'
+    Type: String
+  ParentAlertStack:
+    Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
+    Type: String
+    Default: ''
+  ParentZoneStack:
+    Description: 'Optional stack name of parent zone stack based on vpc/zone-*.yaml template.'
+    Type: String
+    Default: ''
+  LoadBalancerPriority:
+    Description: 'The priority for the rule. Elastic Load Balancing evaluates rules in priority order, from the lowest value to the highest value. If a request satisfies a rule, Elastic Load Balancing ignores all subsequent rules. A target group can have only one rule with a given priority.'
+    Type: Number
+    Default: 1
+    ConstraintDescription: 'Must be in the range [1-99999]'
+    MinValue: 1
+    MaxValue: 99999
+  LoadBalancerHostPattern:
+    Description: 'Optional host pattern. Specify LoadBalancerPathPattern and/or LoadBalancerHostPattern.'
+    Type: String
+    Default: ''
+    ConstraintDescription: 'Must not be longer than 255'
+    MaxLength: 255
+  LoadBalancerPathPattern:
+    Description: 'Optional path pattern. Specify LoadBalancerPathPattern and/or LoadBalancerHostPattern.'
+    Type: String
+    Default: '/*'
+    ConstraintDescription: 'Must not be longer than 255'
+    MaxLength: 255
+  LoadBalancerHttps:
+    Description: 'If the cluster supports HTTPS (LoadBalancerCertificateArn is set) you can enable HTTPS for the service'
+    Type: String
+    Default: false
+    AllowedValues:
+    - true
+    - false
+  LoadBalancerDeregistrationDelay:
+    Description: 'The amount time (in seconds) to wait before changing the state of a deregistering target from draining to unused.'
+    Type: Number
+    Default: 60
+    ConstraintDescription: 'Must be in the range [0-3600]'
+    MinValue: 0
+    MaxValue: 3600
+  SubDomainNameWithDot:
+    Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
+    Type: String
+    Default: ''
+Conditions:
+  HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
+  HasLoadBalancerPathPattern: !Not [!Equals [!Ref LoadBalancerPathPattern, '']]
+  HasLoadBalancerHostPattern: !Not [!Equals [!Ref LoadBalancerHostPattern, '']]
+  HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
+Resources:
+  TargetGroup:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckIntervalSeconds: 15
+      HealthCheckPath: '/'
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      Matcher:
+        HttpCode: '200-299'
+      Port: 8080 # overriden when containers are attached
+      Protocol: HTTP
+      TargetType: ip
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: !Ref LoadBalancerDeregistrationDelay
+      VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
+  RecordSet:
+    Condition: HasZone
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      AliasTarget:
+        HostedZoneId: {'Fn::ImportValue': !Sub '${ParentClusterStack}-CanonicalHostedZoneID'}
+        DNSName: {'Fn::ImportValue': !Sub '${ParentClusterStack}-DNSName'}
+      HostedZoneId: {'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneId'}
+      Name: !Sub
+      - '${SubDomainNameWithDot}${HostedZoneName}'
+      - SubDomainNameWithDot: !Ref SubDomainNameWithDot
+        HostedZoneName: {'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneName'}
+      Type: A
+  HTTPCodeTarget5XXTooHighAlarm:
+    Condition: HasAlertTopic
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Application load balancer receives 5XX HTTP status codes from targets'
+      Namespace: 'AWS/ApplicationELB'
+      MetricName: HTTPCode_Target_5XX_Count
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+      Dimensions:
+      - Name: LoadBalancer
+        Value: !GetAtt TargetGroup.TargetGroupFullName
+      - Name: !Ref TargetGroup
+        Value: !GetAtt TargetGroup.TargetGroupFullName
+      TreatMissingData: notBreaching
+  TargetConnectionErrorCountTooHighAlarm:
+    Condition: HasAlertTopic
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Application load balancer could not connect to targets'
+      Namespace: 'AWS/ApplicationELB'
+      MetricName: TargetConnectionErrorCount
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+      Dimensions:
+      - Name: LoadBalancer
+        Value: !GetAtt TargetGroup.TargetGroupFullName
+      - Name: !Ref TargetGroup
+        Value: !GetAtt TargetGroup.TargetGroupFullName
+      TreatMissingData: notBreaching
+  LoadBalancerListenerRule:
+    Type: 'AWS::ElasticLoadBalancingV2::ListenerRule'
+    Properties:
+      Actions:
+      - Type: forward
+        TargetGroupArn: !Ref TargetGroup
+      Conditions: !If
+      - HasLoadBalancerPathPattern
+      - !If
+        - HasLoadBalancerHostPattern
+        - - Field: host-header
+            Values:
+            - !Ref LoadBalancerHostPattern
+          - Field: path-pattern
+            Values:
+            - !Sub '${LoadBalancerPathPattern}'
+        - - Field: path-pattern
+            Values:
+            - !Sub '${LoadBalancerPathPattern}'
+      - !If
+        - HasLoadBalancerHostPattern
+        - - Field: host-header
+            Values:
+            - !Ref LoadBalancerHostPattern
+        - [] # neither LoadBalancerHostPattern nor LoadBalancerPathPattern specified
+      ListenerArn: !If [HasLoadBalancerHttps, {'Fn::ImportValue': !Sub '${ParentClusterStack}-HttpsListener'}, {'Fn::ImportValue': !Sub '${ParentClusterStack}-HttpListener'}]
+      Priority: !Ref LoadBalancerPriority
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'fargate/cluster-alb-target'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+  TargetGroup:
+    Description: 'Security Group for Load Balancer'
+    Value: !Ref TargetGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-TargetGroup'
+  SecurityGroup:
+    Description: 'Security Group for Load Balancer'
+    Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-LoadBalancerSecurityGroup'}
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroup'

--- a/fargate/cluster-alb-target.yaml
+++ b/fargate/cluster-alb-target.yaml
@@ -23,6 +23,7 @@ Metadata:
       - ParentVPCStack
       - ParentClusterStack
       - ParentAlertStack
+      - ParentZoneStack
     - Label:
         default: 'Load Balancer Parameters'
       Parameters:
@@ -31,6 +32,10 @@ Metadata:
       - LoadBalancerPathPattern
       - LoadBalancerHttps
       - LoadBalancerDeregistrationDelay
+    - Label:
+        default: 'Service Parameters'
+      Parameters:
+      - SubDomainNameWithDot
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -40,6 +45,10 @@ Parameters:
     Type: String
   ParentAlertStack:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
+    Type: String
+    Default: ''
+  ParentZoneStack:
+    Description: 'Optional stack name of parent zone stack based on vpc/zone-*.yaml template.'
     Type: String
     Default: ''
   LoadBalancerPriority:
@@ -75,11 +84,16 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-3600]'
     MinValue: 0
     MaxValue: 3600
+  SubDomainNameWithDot:
+    Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
+    Type: String
+    Default: ''
 Conditions:
   HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
   HasLoadBalancerPathPattern: !Not [!Equals [!Ref LoadBalancerPathPattern, '']]
   HasLoadBalancerHostPattern: !Not [!Equals [!Ref LoadBalancerHostPattern, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
 Resources:
   TargetGroup:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
@@ -99,6 +113,19 @@ Resources:
       - Key: deregistration_delay.timeout_seconds
         Value: !Ref LoadBalancerDeregistrationDelay
       VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
+  RecordSet:
+    Condition: HasZone
+    Type: 'AWS::Route53::RecordSet'
+    Properties:
+      AliasTarget:
+        HostedZoneId: {'Fn::ImportValue': !Sub '${ParentClusterStack}-CanonicalHostedZoneID'}
+        DNSName: {'Fn::ImportValue': !Sub '${ParentClusterStack}-DNSName'}
+      HostedZoneId: {'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneId'}
+      Name: !Sub
+      - '${SubDomainNameWithDot}${HostedZoneName}'
+      - SubDomainNameWithDot: !Ref SubDomainNameWithDot
+        HostedZoneName: {'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneName'}
+      Type: A
   HTTPCodeTarget5XXTooHighAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'

--- a/fargate/service.yaml
+++ b/fargate/service.yaml
@@ -540,15 +540,13 @@ Resources:
           ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
           SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentALBTargetStack}-SecurityGroup'}
         - !Ref 'AWS::NoValue'
-  ServiceSecurityGroupInSSHBastion:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Condition: HasSSHBastionSecurityGroup
-    Properties:
-      GroupId: !Ref ServiceSecurityGroup
-      IpProtocol: tcp
-      FromPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
-      ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
-      SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentSSHBastionStack}-SecurityGroup'}
+      - !If
+        - HasSSHBastionSecurityGroup
+        - IpProtocol: tcp
+          FromPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentSSHBastionStack}-SecurityGroup'}
+        - !Ref 'AWS::NoValue'
   Service:
     Type: 'AWS::ECS::Service'
     Properties:

--- a/fargate/service.yaml
+++ b/fargate/service.yaml
@@ -1,0 +1,750 @@
+---
+# Copyright 2019 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Fargate: service that runs on a Fargate cluster based on fargate/cluster.yaml with service discovery via Cloud Map, a cloudonaut.io template'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentVPCStack
+      - ParentClusterStack
+      - ParentAlertStack
+      - ParentCloudMapStack
+      - ParentCloudMapIngressStack
+      - ParentALBTargetStack
+      - ParentClientStack1
+      - ParentClientStack2
+      - ParentClientStack3
+      - ParentSSHBastionStack
+    - Label:
+        default: 'Task Parameters'
+      Parameters:
+      - TaskPolicies
+      - ProxyImage
+      - ProxyCommand
+      - ProxyPort
+      - ProxyEnvironment1Key
+      - ProxyEnvironment1Value
+      - ProxyEnvironment2Key
+      - ProxyEnvironment2Value
+      - ProxyEnvironment3Key
+      - ProxyEnvironment3Value
+      - AppImage
+      - AppCommand
+      - AppPort
+      - AppEnvironment1Key
+      - AppEnvironment1Value
+      - AppEnvironment2Key
+      - AppEnvironment2Value
+      - AppEnvironment3Key
+      - AppEnvironment3Value
+      - SidecarImage
+      - SidecarCommand
+      - SidecarPort
+      - SidecarEnvironment1Key
+      - SidecarEnvironment1Value
+      - SidecarEnvironment2Key
+      - SidecarEnvironment2Value
+      - SidecarEnvironment3Key
+      - SidecarEnvironment3Value
+    - Label:
+        default: 'Service Parameters'
+      Parameters:
+      - CloudMapName
+      - Cpu
+      - Memory
+      - SubnetsReach
+      - AutoScaling
+      - DesiredCount
+      - MaxCapacity
+      - MinCapacity
+      - HealthCheckGracePeriod
+      - LogsRetentionInDays
+Parameters:
+  ParentVPCStack:
+    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Type: String
+  ParentClusterStack:
+    Description: 'Stack name of parent Cluster stack based on fargate/cluster.yaml template.'
+    Type: String
+  ParentAlertStack:
+    Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
+    Type: String
+    Default: ''
+  ParentCloudMapStack:
+    Description: 'Stack name of parent Cloud Map stack based on vpc/cloudmap-private.yaml template.'
+    Type: String
+    Default: ''
+  ParentCloudMapIngressStack:
+    Description: 'Stack name of parent client stack based on state/client-sg.yaml template.'
+    Type: String
+    Default: ''
+  CloudMapName:
+    Description: 'The name of the service used for service discovery (Cloud Map).'
+    Type: String
+    Default: ''
+  ParentALBTargetStack:
+    Description: 'Stack name of parent cluster ALB service stack based on fargate/cluster-alb-target.yaml template.'
+    Type: String
+    Default: ''
+  ParentClientStack1:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentClientStack2:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentClientStack3:
+    Description: 'Optional stack name of parent Client Security Group stack based on state/client-sg.yaml template to allow network access from the service to whatever uses the client security group.'
+    Type: String
+    Default: ''
+  ParentSSHBastionStack:
+    Description: 'Optional but recommended stack name of parent SSH bastion host/instance stack based on vpc/vpc-*-bastion.yaml template.'
+    Type: String
+    Default: ''
+  TaskPolicies:
+    Description: 'Comma-delimited list of IAM managed policy ARNs to attach to the task IAM role'
+    Type: String
+    Default: ''
+  ProxyImage:
+    Description: 'Optional Docker image to use for the proxy container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  ProxyCommand:
+    Description: 'Optional command used when starting the proxy container.'
+    Type: String
+    Default: ''
+  ProxyPort:
+    Description: 'The port exposed by the proxy container that receives traffic from the load balancer (ProxyPort <> AppPort <> SidecarPort; ignored if ProxyImage is not set).'
+    Type: Number
+    # zero is not a valid port and indicates no port was provided
+    Default: 0
+    MinValue: 0
+    MaxValue: 49150
+  ProxyEnvironment1Key:
+    Description: 'Optional environment variable 1 key for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment1Value:
+    Description: 'Optional environment variable 1 value for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment2Key:
+    Description: 'Optional environment variable 2 key for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment2Value:
+    Description: 'Optional environment variable 2 value for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment3Key:
+    Description: 'Optional environment variable 3 key for proxy container.'
+    Type: String
+    Default: ''
+  ProxyEnvironment3Value:
+    Description: 'Optional environment variable 3 value for proxy container.'
+    Type: String
+    Default: ''
+  AppImage:
+    Description: 'The Docker image to use for the app container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: 'widdix/hello:v1'
+  AppCommand:
+    Description: 'Optional commands (comma-delimited) used when starting the app container.'
+    Type: String
+    Default: ''
+  AppPort:
+    Description: 'The port exposed by the app container that receives traffic from the load balancer or the proxy container (AppPort <> ProxyPort <> SidecarPort).'
+    Type: Number
+    # zero is not a valid port and indicates no port was provided
+    Default: 0
+    MinValue: 0
+    MaxValue: 49150
+  AppEnvironment1Key:
+    Description: 'Optional environment variable 1 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment1Value:
+    Description: 'Optional environment variable 1 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment2Key:
+    Description: 'Optional environment variable 2 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment2Value:
+    Description: 'Optional environment variable 2 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment3Key:
+    Description: 'Optional environment variable 3 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment3Value:
+    Description: 'Optional environment variable 3 value for app container.'
+    Type: String
+    Default: ''
+  SidecarImage:
+    Description: 'Optional Docker image to use for the sidecar container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
+    Type: String
+    Default: ''
+  SidecarCommand:
+    Description: 'Optional command used when starting the sidecar container.'
+    Type: String
+    Default: ''
+  SidecarPort:
+    Description: 'The port exposed by the sidecar container reachable from the app container on host localhost (SidecarPort <> ProxyPort <> AppPort).'
+    Type: Number
+    # zero is not a valid port and indicates no port was provided
+    Default: 0
+    MinValue: 0
+    MaxValue: 49150
+  SidecarEnvironment1Key:
+    Description: 'Optional environment variable 1 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment1Value:
+    Description: 'Optional environment variable 1 value for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment2Key:
+    Description: 'Optional environment variable 2 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment2Value:
+    Description: 'Optional environment variable 2 value for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment3Key:
+    Description: 'Optional environment variable 3 key for sidecar container.'
+    Type: String
+    Default: ''
+  SidecarEnvironment3Value:
+    Description: 'Optional environment variable 3 value for sidecar container.'
+    Type: String
+    Default: ''
+  Cpu:
+    Description: 'The minimum number of vCPUs to reserve for the container.'
+    Type: String
+    Default: '0.25'
+    AllowedValues: ['0.25', '0.5', '1', '2', '4']
+  Memory:
+    Description: 'The amount (in GB) of memory used by the task.'
+    Type: String
+    Default: '0.5'
+    AllowedValues: ['0.5', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30']
+  DesiredCount:
+    Description: 'The number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 2
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  MaxCapacity:
+    Description: 'The maximum number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 4
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  MinCapacity:
+    Description: 'The minimum number of simultaneous tasks, that you want to run on the cluster.'
+    Type: Number
+    Default: 2
+    ConstraintDescription: 'Must be >= 1'
+    MinValue: 1
+  LogsRetentionInDays:
+    Description: 'Specifies the number of days you want to retain log events in the specified log group.'
+    Type: Number
+    Default: 14
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  SubnetsReach:
+    Description: 'Should the service have direct access to the Internet or do you prefer private subnets with NAT?'
+    Type: String
+    Default: Public
+    AllowedValues:
+    - Public
+    - Private
+  AutoScaling:
+    Description: 'Scale number of tasks based on CPU load?'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+  HealthCheckGracePeriod:
+    Description: 'The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started.'
+    Type: Number
+    # invalid value functions as empty
+    Default: -1
+    MinValue: -1
+    MaxValue: 1800
+Mappings:
+  CpuMap:
+    '0.25':
+      Cpu: 256
+    '0.5':
+      Cpu: 512
+    '1':
+      Cpu: 1024
+    '2':
+      Cpu: 2048
+    '4':
+      Cpu: 4096
+  MemoryMap:
+    '0.5':
+      Memory: 512
+    '1':
+      Memory: 1024
+    '2':
+      Memory: 2048
+    '3':
+      Memory: 3072
+    '4':
+      Memory: 4096
+    '5':
+      Memory: 5120
+    '6':
+      Memory: 6144
+    '7':
+      Memory: 7168
+    '8':
+      Memory: 8192
+    '9':
+      Memory: 9216
+    '10':
+      Memory: 10240
+    '11':
+      Memory: 11264
+    '12':
+      Memory: 12288
+    '13':
+      Memory: 13312
+    '14':
+      Memory: 14336
+    '15':
+      Memory: 15360
+    '16':
+      Memory: 16384
+    '17':
+      Memory: 17408
+    '18':
+      Memory: 18432
+    '19':
+      Memory: 19456
+    '20':
+      Memory: 20480
+    '21':
+      Memory: 21504
+    '22':
+      Memory: 22528
+    '23':
+      Memory: 23552
+    '24':
+      Memory: 24576
+    '25':
+      Memory: 25600
+    '26':
+      Memory: 26624
+    '27':
+      Memory: 27648
+    '28':
+      Memory: 28672
+    '29':
+      Memory: 29696
+    '30':
+      Memory: 30720
+Conditions:
+  HasHealthCheckGracePeriod: !Not [!Equals [!Ref HealthCheckGracePeriod, -1]]
+  HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
+  HasServiceDiscovery: !Not [!Equals [!Ref ParentCloudMapStack, '']]
+  HasALBTarget: !Not [!Equals [!Ref ParentALBTargetStack, '']]
+  HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
+  HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
+  HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
+  HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
+  HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
+  HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
+  HasTaskPolicies: !Not [!Equals [!Ref TaskPolicies, '']]
+  HasAppCommand: !Not [!Equals [!Ref AppCommand, '']]
+  HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
+  HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
+  HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
+  HasProxyImage: !Not [!Equals [!Ref ProxyImage, '']]
+  HasProxyCommand: !Not [!Equals [!Ref ProxyCommand, '']]
+  HasProxyEnvironment1Key: !Not [!Equals [!Ref ProxyEnvironment1Key, '']]
+  HasProxyEnvironment2Key: !Not [!Equals [!Ref ProxyEnvironment2Key, '']]
+  HasProxyEnvironment3Key: !Not [!Equals [!Ref ProxyEnvironment3Key, '']]
+  HasSidecarImage: !Not [!Equals [!Ref SidecarImage, '']]
+  HasSidecarCommand: !Not [!Equals [!Ref SidecarCommand, '']]
+  HasSidecarEnvironment1Key: !Not [!Equals [!Ref SidecarEnvironment1Key, '']]
+  HasSidecarEnvironment2Key: !Not [!Equals [!Ref SidecarEnvironment2Key, '']]
+  HasSidecarEnvironment3Key: !Not [!Equals [!Ref SidecarEnvironment3Key, '']]
+  HasAppPort: !Not [!Equals [!Ref AppPort, 0]]
+  HasProxyPort: !And [!Condition HasProxyImage, !Not [!Equals [!Ref ProxyPort, 0]]]
+  HasSidecarPort: !And [!Condition HasSidecarImage, !Not [!Equals [!Ref SidecarPort, 0]]]
+  HasExposedPort: !Or [!Condition HasAppPort, !Condition HasProxyPort]
+Rules:
+  CloudMapRequirements:
+    RuleCondition: !Not [!Equals [!Ref ParentCloudMapStack, '']]
+    Assertions:
+    - AssertDescription: CloudMapName required if ParentCloudMapStack present
+      Assert: !Not [!Equals [!Ref ParentCloudMapStack, '']]
+    - AssertDescription: ParentCloudMapIngressStack required if ParentCloudMapStack present
+      Assert: !Not [!Equals [!Ref ParentCloudMapIngressStack, '']]
+Resources:
+  TaskExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'ecs-tasks.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: AmazonECSTaskExecutionRolePolicy # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ecr:GetAuthorizationToken'
+            - 'ecr:BatchCheckLayerAvailability'
+            - 'ecr:GetDownloadUrlForLayer'
+            - 'ecr:BatchGetImage'
+            Resource: '*'
+          - Effect: Allow
+            Action:
+            - 'logs:CreateLogStream'
+            - 'logs:PutLogEvents'
+            Resource: !GetAtt 'LogGroup.Arn'
+  TaskRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'ecs-tasks.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      ManagedPolicyArns: !If [HasTaskPolicies, !Split [',', !Ref TaskPolicies], !Ref 'AWS::NoValue']
+  TaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+      - !If
+        - HasProxyImage
+        - Name: proxy
+          Image: !Ref ProxyImage
+          Command: !If [HasProxyCommand, !Ref ProxyCommand, !Ref 'AWS::NoValue']
+          PortMappings:
+          - !If
+            - HasProxyPort
+            - ContainerPort: !Ref ProxyPort
+              Protocol: tcp
+            - !Ref 'AWS::NoValue'
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              'awslogs-region': !Ref 'AWS::Region'
+              'awslogs-group': !Ref LogGroup
+              'awslogs-stream-prefix': proxy
+          Environment:
+          - !If [HasProxyEnvironment1Key, {Name: !Ref ProxyEnvironment1Key, Value: !Ref ProxyEnvironment1Value}, !Ref 'AWS::NoValue']
+          - !If [HasProxyEnvironment2Key, {Name: !Ref ProxyEnvironment2Key, Value: !Ref ProxyEnvironment2Value}, !Ref 'AWS::NoValue']
+          - !If [HasProxyEnvironment3Key, {Name: !Ref ProxyEnvironment3Key, Value: !Ref ProxyEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !Ref 'AWS::NoValue'
+      - Name: app
+        Image: !Ref AppImage
+        Command: !If [HasAppCommand, !Split [',', !Ref AppCommand], !Ref 'AWS::NoValue']
+        PortMappings:
+        - !If
+          - HasAppPort
+          - ContainerPort: !Ref AppPort
+            Protocol: tcp
+          - !Ref 'AWS::NoValue'
+        Essential: true
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            'awslogs-region': !Ref 'AWS::Region'
+            'awslogs-group': !Ref LogGroup
+            'awslogs-stream-prefix': app
+        Environment:
+        - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
+      - !If
+        - HasSidecarImage
+        - Name: sidecar
+          Image: !Ref SidecarImage
+          Command: !If [HasSidecarCommand, !Ref SidecarCommand, !Ref 'AWS::NoValue']
+          PortMappings:
+          - !If
+            - HasSidecarPort
+            - ContainerPort: !Ref SidecarPort
+              Protocol: tcp
+            - !Ref 'AWS::NoValue'
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              'awslogs-region': !Ref 'AWS::Region'
+              'awslogs-group': !Ref LogGroup
+              'awslogs-stream-prefix': sidecar
+          Environment:
+          - !If [HasSidecarEnvironment1Key, {Name: !Ref SidecarEnvironment1Key, Value: !Ref SidecarEnvironment1Value}, !Ref 'AWS::NoValue']
+          - !If [HasSidecarEnvironment2Key, {Name: !Ref SidecarEnvironment2Key, Value: !Ref SidecarEnvironment2Value}, !Ref 'AWS::NoValue']
+          - !If [HasSidecarEnvironment3Key, {Name: !Ref SidecarEnvironment3Key, Value: !Ref SidecarEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !Ref 'AWS::NoValue'
+      Cpu: !FindInMap [CpuMap, !Ref Cpu, Cpu]
+      ExecutionRoleArn: !GetAtt 'TaskExecutionRole.Arn'
+      Family: !Ref 'AWS::StackName'
+      Memory: !FindInMap [MemoryMap, !Ref Memory, Memory]
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      TaskRoleArn: !GetAtt 'TaskRole.Arn'
+  LogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      RetentionInDays: !Ref LogsRetentionInDays
+  ServiceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Sub '${AWS::StackName}-service'
+      VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
+      SecurityGroupIngress:
+      - !If
+        - HasServiceDiscovery
+        - IpProtocol: tcp
+          FromPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentCloudMapIngressStack}-ClientSecurityGroup'}
+        - !Ref 'AWS::NoValue'
+      - !If
+        - HasALBTarget
+        - IpProtocol: tcp
+          FromPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentALBTargetStack}-SecurityGroup'}
+        - !Ref 'AWS::NoValue'
+  ServiceSecurityGroupInSSHBastion:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: HasSSHBastionSecurityGroup
+    Properties:
+      GroupId: !Ref ServiceSecurityGroup
+      IpProtocol: tcp
+      FromPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+      ToPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+      SourceSecurityGroupId: {'Fn::ImportValue': !Sub '${ParentSSHBastionStack}-SecurityGroup'}
+  Service:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: !Ref DesiredCount
+      HealthCheckGracePeriodSeconds: !If [HasHealthCheckGracePeriod, !Ref HealthCheckGracePeriod, !Ref 'AWS::NoValue']
+      LaunchType: FARGATE
+      LoadBalancers:
+      - !If
+        - HasExposedPort
+        - ContainerName: !If [HasProxyImage, proxy, app]
+          ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          TargetGroupArn: {'Fn::ImportValue': !Sub '${ParentALBTargetStack}-TargetGroup'}
+        - !Ref 'AWS::NoValue'
+      ServiceRegistries:
+      - !If
+        - HasServiceDiscovery
+        - ContainerName: !If [HasProxyImage, proxy, app]
+          ContainerPort: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+          RegistryArn: !GetAtt 'ServiceDiscovery.Arn'
+        - !Ref 'AWS::NoValue'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !If [HasSubnetsReachPublic, ENABLED, DISABLED]
+          SecurityGroups:
+          - !Ref ServiceSecurityGroup
+          - !If [HasClientSecurityGroup1, {'Fn::ImportValue': !Sub '${ParentClientStack1}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup2, {'Fn::ImportValue': !Sub '${ParentClientStack2}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          - !If [HasClientSecurityGroup3, {'Fn::ImportValue': !Sub '${ParentClientStack3}-ClientSecurityGroup'}, !Ref 'AWS::NoValue']
+          Subnets: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-Subnets${SubnetsReach}'}]
+      TaskDefinition: !Ref TaskDefinition
+  CPUUtilizationTooHighAlarm:
+    Condition: HasAlertTopic
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Average CPU utilization over last 10 minutes higher than 80%'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 80
+      AlarmActions:
+      - {'Fn::ImportValue': !Sub '${ParentAlertStack}-TopicARN'}
+  ScalableTargetRole: # based on http://docs.aws.amazon.com/AmazonECS/latest/developerguide/autoscale_IAM_role.html
+    Condition: HasAutoScaling
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: 'application-autoscaling.amazonaws.com'
+          Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: AmazonEC2ContainerServiceAutoscaleRole
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ecs:DescribeServices'
+            - 'ecs:UpdateService'
+            Resource: '*'
+      - PolicyName: cloudwatch
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'cloudwatch:DescribeAlarms'
+            Resource: '*'
+  ScalableTarget:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalableTarget'
+    Properties:
+      MaxCapacity: !Ref MaxCapacity
+      MinCapacity: !Ref MinCapacity
+      ResourceId: !Sub
+      - 'service/${Cluster}/${Service}'
+      - Cluster: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+        Service: !GetAtt 'Service.Name'
+      RoleARN: !GetAtt 'ScalableTargetRole.Arn'
+      ScalableDimension: 'ecs:service:DesiredCount'
+      ServiceNamespace: ecs
+  ScaleUpPolicy:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: !Sub '${AWS::StackName}-scale-up'
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+        - MetricIntervalLowerBound: 0
+          ScalingAdjustment: 25
+  ScaleDownPolicy:
+    Condition: HasAutoScaling
+    Type: 'AWS::ApplicationAutoScaling::ScalingPolicy'
+    Properties:
+      PolicyName: !Sub '${AWS::StackName}-scale-down'
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 300
+        MinAdjustmentMagnitude: 1
+        StepAdjustments:
+        - MetricIntervalUpperBound: 0
+          ScalingAdjustment: -25
+  CPUUtilizationHighAlarm:
+    Condition: HasAutoScaling
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Service is running out of CPU'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 60
+      AlarmActions:
+      - !Ref ScaleUpPolicy
+  CPUUtilizationLowAlarm:
+    Condition: HasAutoScaling
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: 'Service is wasting CPU'
+      Namespace: 'AWS/ECS'
+      Dimensions:
+      - Name: ClusterName
+        Value: {'Fn::ImportValue': !Sub '${ParentClusterStack}-Cluster'}
+      - Name: ServiceName
+        Value: !GetAtt 'Service.Name'
+      MetricName: CPUUtilization
+      ComparisonOperator: LessThanThreshold
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 3
+      Threshold: 30
+      AlarmActions:
+      - !Ref ScaleDownPolicy
+  ServiceDiscovery:
+    Condition: HasServiceDiscovery
+    Type: 'AWS::ServiceDiscovery::Service'
+    Properties:
+      Description: !Ref 'AWS::StackName'
+      DnsConfig:
+        DnsRecords:
+        - Type: A
+          TTL: 30
+        - Type: SRV
+          TTL: 30
+        NamespaceId: {'Fn::ImportValue': !Sub '${ParentCloudMapStack}-NamespaceID'}
+        RoutingPolicy: MULTIVALUE
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: !Ref CloudMapName
+      NamespaceId: {'Fn::ImportValue': !Sub '${ParentCloudMapStack}-NamespaceID'}
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'fargate/service'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+  SecurityGroup:
+    Description: 'Security Group attached to the service'
+    Value: !Ref ServiceSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroup'
+  ServicePort:
+    Condition: HasExposedPort
+    Description: 'Port used by the service'
+    Value: !If [HasProxyImage, !Ref ProxyPort, !Ref AppPort]
+    Export:
+      Name: !Sub '${AWS::StackName}-Port'


### PR DESCRIPTION
While working through our CF implementation, I ran into two cases not covered by the existing templates:

 - A fargate service with no exposed ports (also mentioned in #358)
 - A fargate service attached to *both* an internal cloudmap (e.g. at `<service>.local`) and an external ALB where the service can be accessed (over SSL) by external users (e.g. at `<service>.<mydomain>.com`).

This PR demonstrates a single `fargate/service` template that configures all (or none) of these services depending on the parameters provided.  

- The template is basically a drop-in replacement for `fargate/service-cloudmap` except that I renamed `ParentClientStack` to `ParentCloudMapIngressStack` and `Name` to `CloudMapName` to better link the parameter to the feature (could be reverted).
- To replicate the behavior of the existing `fargate/service-cluster-alb`, a user would combine `fargate/service` with the new `fargate/cluster-alb-target` shim:

	```
	  Service:
		Type: 'AWS::CloudFormation::Stack'
		Properties:
		  Parameters:
			...
			ParentALBTargetStack: !GetAtt 'ServiceALBTarget.Outputs.StackName'
			...
		  TemplateURL: 'aws-cf-templates/fargate/service.yaml'
	  ServiceALBTarget:
		Type: 'AWS::CloudFormation::Stack'
		Properties:
		  Parameters:
			...
		  TemplateURL: 'aws-cf-templates/fargate/cluster-alb-target.yaml'
	```

We're using both of these files internally.  If the approach was interesting, I could create a shim for `service-dedicated-alb` as well.  I've made additional improvements to these templates in another branch of our Repo, but I wanted to offer a 1:1 replacement for consideration.