### PR TITLE
Improve Jenkins templates with more configurable options

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -11,3 +11,31 @@ To update the region map execute the following lines in your terminal:
 $ regions=$(aws ec2 describe-regions --query "Regions[].RegionName" --output text)
 $ for region in $regions; do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20191116.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
+## Deploying
+
+1. Deploy the VPC
+The VPC is a dependency of the Jenkins stack.
+
+    aws cloudformation deploy \
+        --profile <IAM_USER_PROFILE> \
+        --capabilities CAPABILITY_IAM \
+        --s3-bucket "unmanaged-cf-templates-<ACCOUNT_ID>" \
+        --stack-name "<NAME_OF_THE_VPC_STACK>" \
+        --template-file "./../vpc/vpc-2azs.yaml" \
+
+2. Deploy the Jenkins stack.
+*Note*: this will set the CIDR whitelist to the current public IPv4 address of the workstation where the `aws cloudformation deploy` is run.
+
+    aws cloudformation deploy \
+        --profile <IAM_USER_PROFILE> \
+        --capabilities CAPABILITY_IAM \
+        --parameter-overrides \
+            AgentEnableMetrics="<true|false>" \
+            CIDRWhiteList="$(dig +short myip.opendns.com @resolver1.opendns.com)/32" \
+            KeyName="<SSH_KEYPAIR_NAME>" \
+            MasterAdminPassword="admin_password" \
+            MasterEnableMetrics="true" \
+            ParentVPCStack="<NAME_OF_THE_VPC_STACK>" \
+        --s3-bucket "unmanaged-cf-templates-templates-<ACCOUNT_ID>" \
+        --stack-name "<NAME_OF_THE_JENKINS_STACK>" \
+        --template-file "./jenkins2-ha-agents.yaml"

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -50,6 +50,7 @@ Metadata:
       - MasterLogsRetentionInDays
       - MasterVolumeSize
       - MasterLoadBalancerIdleTimeout
+      - MasterEnableMetrics
     - Label:
         default: 'Agent Parameters'
       Parameters:
@@ -60,6 +61,15 @@ Metadata:
       - AgentMinSize
       - AgentMaxBuildWaitTimeInSeconds
       - AgentLogsRetentionInDays
+      - AgentEnableMetrics
+    - Label:
+        default: 'Security'
+      Parameters:
+      - CIDRWhiteList
+    - Label:
+        default: 'Jenkins'
+      Parameters:
+      - JenkinsPackage
 Parameters:
   ParentVPCStack:
     Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
@@ -117,7 +127,7 @@ Parameters:
     - 'internet-facing'
     - internal
   MasterInstanceType:
-    Description: 'The instance type of the Jenkins master.'
+    Description: 'The instance type of the Jenkins master. t2.micro works but t3.medium is better.'
     Type: String
     Default: 't2.micro'
   MasterAdminPassword:
@@ -144,6 +154,11 @@ Parameters:
     Default: 60
     MinValue: 1
     MaxValue: 4000
+  MasterEnableMetrics:
+    Description: 'Should the master have Group Metrics collection enabled?'
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
   AgentSubnetsReach:
     Description: 'Should the agents have direct access to the Internet or do you prefer private subnets with NAT?'
     Type: String
@@ -152,7 +167,7 @@ Parameters:
     - Public
     - Private
   AgentInstanceType:
-    Description: 'The instance type of the Jenkins agents.'
+    Description: 'The instance type of the Jenkins agents. t2.micro works but t3.medium or c5.large work better.'
     Type: String
     Default: 't2.micro'
   AgentVolumeSize:
@@ -186,6 +201,11 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  AgentEnableMetrics:
+    Description: 'Should the slave have Group Metrics collection enabled?'
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
@@ -208,6 +228,14 @@ Parameters:
     Description: 'A CRON expression specifying when AWS Backup initiates a backup job.'
     Type: String
     Default: 'cron(0 5 ? * * *)'
+  CIDRWhiteList:
+    Description: 'A whitelist of CIDR ranges which will be allowed to access Jenkins.'
+    # AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
+    Type: String
+  JenkinsPackage:
+    Description: 'The name of the package to install from this list: https://pkg.jenkins.io/redhat-stable/'
+    Type: String
+    Default: 'jenkins-2.204.1-1.1.noarch.rpm'
 Mappings:
   RegionMap:
     'eu-north-1':
@@ -265,6 +293,8 @@ Conditions:
   HasAlertTopicAndEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasEFSProvisionedThroughput]
   HasAlertTopicAndNotEFSProvisionedThroughput: !And [!Condition HasAlertTopic, !Condition HasNotEFSProvisionedThroughput]
   HasEFSBackupRetentionPeriod: !Not [!Equals [!Ref EFSBackupRetentionPeriod, 0]]
+  HasMasterMetrics: !Equals [!Ref MasterEnableMetrics, "true"]
+  HasAgentMetrics: !Equals [!Ref AgentEnableMetrics, "true"]
 Resources:
   MasterStorageSG:
     Type: 'AWS::EC2::SecurityGroup'
@@ -363,7 +393,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
-      CidrIp: '0.0.0.0/0'
+      CidrIp: !Ref CIDRWhiteList
   MasterELBSGInAuthProxy:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: HasAuthProxySecurityGroup
@@ -885,7 +915,7 @@ Resources:
         install:
           packages:
             rpm:
-              jenkins: 'https://pkg.jenkins.io/redhat-stable/jenkins-2.204.1-1.1.noarch.rpm'
+              jenkins: !Join [ "/", ['https://pkg.jenkins.io/redhat-stable', !Ref JenkinsPackage ] ]
             yum:
               'java-1.8.0-amazon-corretto': []
               'ruby': []
@@ -1307,6 +1337,11 @@ Resources:
       - Key: Name
         Value: 'jenkins-master'
         PropagateAtLaunch: true
+      MetricsCollection: 
+        - Fn::If:
+          - HasMasterMetrics
+          - Granularity: 1Minute
+          - !Ref 'AWS::NoValue'
     CreationPolicy:
       ResourceSignal:
         Timeout: PT15M
@@ -2016,6 +2051,11 @@ Resources:
       - Key: Name
         Value: 'jenkins-agent'
         PropagateAtLaunch: true
+      MetricsCollection: 
+        - Fn::If:
+          - HasAgentMetrics
+          - Granularity: 1Minute
+          - !Ref 'AWS::NoValue'
     CreationPolicy:
       ResourceSignal:
         Timeout: PT10M

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFS=$'\n\t'
+
+#####
+# TODO
+#       + Validate
+#       + Destroy
+#####
+
+# See: http://wiki.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+export PS5='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+# Absolute path to current dir.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+declare vpc_stack_name="jenkins-vpc"
+
+_usage() {
+    echo "USAGE:"
+    echo -e "\tAWS_PROFILE=my_aws_profile_name $1"
+}
+
+_generate_ssh_key() {
+    : # ssh-keygen -t rsa -b 4096 -C "spargo-aws-control@spargoinc.com"
+}
+
+declare AWS_PROFILE=${AWS_PROFILE:-}
+if [[ -z $AWS_PROFILE ]]; then
+    echo "You must specify your AWS profile name"
+    echo "See: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html"
+    _usage
+    exit 255
+fi
+echo "Using AWS profile ${AWS_PROFILE}"
+
+_get_account_id() {
+    aws sts \
+        get-caller-identity \
+            --query Account \
+            --output text
+}
+
+# Create s3 bucket if it doesn't exist.
+# This bucket will hold our templates so that CloudFormation can execute them.
+# You can't omit the bucket using CLI because the template size exceeds the limit set by AWS CLI (51,200 bytes), so uploading works best if you want to do this via terminal.
+_ensure_s3_bucket() {
+    local account_id
+    local bucket_name
+
+    bucket_name="jenkins-cf-templates-$(_get_account_id)"
+
+    aws s3 ls s3://${bucket_name} > /dev/nul 2>&1 || aws s3 mb s3://${bucket_name} > /dev/nul 2>&1
+    echo "${bucket_name}"
+}
+
+# Deploy VPC
+_cf_deploy_vpc() {
+    local bucket=$1
+
+    set -x
+    # Create the VPC structure.
+#    (
+        aws cloudformation deploy \
+            --template-file "${HERE}/../vpc/vpc-2azs.yaml" \
+            --capabilities CAPABILITY_IAM \
+            --s3-bucket $bucket \
+            --stack-name ${vpc_stack_name} # > /dev/null & \
+#    ) && watch \
+#        "aws cloudformation describe-stack-events \
+#            --stack-name $vpc_stack_name | \
+#                jq -r '.StackEvents[] |
+#                        \"\\(.Timestamp | sub(\"\\\\.[0-9]+Z$\"; \"Z\") | fromdate | strftime(\"%H:%M:%S\") ) \\(.LogicalResourceId) \\(.ResourceType) \\(.ResourceStatus)\"
+#                ' | column -t"
+    set +x
+}
+
+_get_my_ip() {
+    dig +short myip.opendns.com @resolver1.opendns.com
+}
+
+# Deploy all other Jenkins resources (EC2, ELB, etc).
+_cf_deploy_jenkins() {
+    local bucket=$1
+    local stack="jenkins-resources"
+
+    set -x
+    #####
+    # TODO:
+    #   These arguments must be inspected before the task is complete.
+    #####
+    # Create all other Jenkins resources.
+    # Credits for watching events as the occur: https://advancedweb.hu/cloudformation-cli-workflows/#deploy-and-watch-the-events
+#    (
+        aws cloudformation deploy \
+            --template-file "${HERE}/jenkins2-ha-agents.yaml" \
+            --capabilities CAPABILITY_IAM \
+            --s3-bucket $bucket \
+            --parameter-overrides \
+            CIDRWhiteList="$(_get_my_ip)/32" \
+                KeyName="spargo-control" \
+                MasterAdminPassword="mypassword" \
+                ParentVPCStack="${vpc_stack_name}" \
+            --stack-name $stack # > /dev/null & \
+#    ) && watch \
+#        "aws cloudformation describe-stack-events \
+#            --stack-name $stack | \
+#                jq -r '.StackEvents[] |
+#                        \"\\(.Timestamp | sub(\"\\\\.[0-9]+Z$\"; \"Z\") | fromdate | strftime(\"%H:%M:%S\") ) \\(.LogicalResourceId) \\(.ResourceType) \\(.ResourceStatus)\"
+#                ' | column -t"
+    set +x
+}
+
+main() {
+    local bucket_name
+
+    # echo "Creating #3 bucket if it doesnt exist..."
+    bucket_name="$(_ensure_s3_bucket)"
+    # echo "S3 bucket '${bucket_name} created."
+
+    # echo "Deploying VPC"
+    # _cf_deploy_vpc ${bucket_name}
+
+    echo "Deploying all Jenkins resources"
+    _cf_deploy_jenkins ${bucket_name}
+}
+
+main $@
+exit $?


### PR DESCRIPTION
Thank  you so much for putting  these templates out into the world!

We've used these templates on multiple engagements but this time  around we have permission from our customer, Spargo, to contribute  the changes back upstream.

I know this is a little chunkier than you want but please consider this PR. We have this setup working  well now.


* Added CIDR whitelist parameter for ELB Security Group
* Added group metrics collection for Jenkins master and build executors, configurable by a CloudFormation parameter
* You can now specify the version of Jenkins to be installed, this allows for more flexibility.
* Added utility script for running CloudFormation templates - with a  safer  initial security group setting
* Added deployment instructions
* Clarified documentation
* Advise on choices for AMI sizes

Co-authored-by: Richard Bullington-McGuire <richard@moduscreate.com>
