### PR TITLE
[Improvement] vpc/vpc* - Add InternetGateway export

### DIFF
--- a/vpc/vpc-2azs.yaml
+++ b/vpc/vpc-2azs.yaml
@@ -264,6 +264,11 @@ Outputs:
     Value: !Ref VPC
     Export:
       Name: !Sub '${AWS::StackName}-VPC'
+  InternetGateway:
+    Description: 'InternetGateway.'
+    Value: !Ref InternetGateway
+    Export:
+      Name: !Sub '${AWS::StackName}-InternetGateway'
   SubnetsPublic:
     Description: 'Subnets public.'
     Value: !Join [',', [!Ref SubnetAPublic, !Ref SubnetBPublic]]

--- a/vpc/vpc-3azs.yaml
+++ b/vpc/vpc-3azs.yaml
@@ -333,6 +333,11 @@ Outputs:
     Value: !Ref VPC
     Export:
       Name: !Sub '${AWS::StackName}-VPC'
+  InternetGateway:
+    Description: 'InternetGateway.'
+    Value: !Ref InternetGateway
+    Export:
+      Name: !Sub '${AWS::StackName}-InternetGateway'
   SubnetsPublic:
     Description: 'Subnets public.'
     Value: !Join [',', [!Ref SubnetAPublic, !Ref SubnetBPublic, !Ref SubnetCPublic]]

--- a/vpc/vpc-4azs.yaml
+++ b/vpc/vpc-4azs.yaml
@@ -402,6 +402,11 @@ Outputs:
     Value: !Ref VPC
     Export:
       Name: !Sub '${AWS::StackName}-VPC'
+  InternetGateway:
+    Description: 'InternetGateway.'
+    Value: !Ref InternetGateway
+    Export:
+      Name: !Sub '${AWS::StackName}-InternetGateway'
   SubnetsPublic:
     Description: 'Subnets public.'
     Value: !Join [',', [!Ref SubnetAPublic, !Ref SubnetBPublic, !Ref SubnetCPublic, !Ref SubnetDPublic]]


### PR DESCRIPTION
We have a use case where we're using one of your VPC templates, and building upon the core network resources with another template to create some additional in-house network resources (NAT gateway, routes to other clouds etc.).

One of the templates needs to access the dynamically created InternetGateway ID in order to add some custom routing rules.

The current workaround is messy and requires manually extracting the InternetGateway ID and adding it as a parameter to the second template. I'm hoping this PR is general purpose enough and that the InternetGateway isn't deliberately excluded from the exports? Thanks!

Workaround:

```yaml
Parameters:
  ParentVPCStack:
    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
    Type: String
  InternetGateway:
    Description: 'Internet gateway for NAT gateway to route to internet'
    Type: String
Resources:
  NatToInternetRoute:
    Type: 'AWS::EC2::Route'
    Properties:
      RouteTableId: !Ref NatToInternetRouteTable
      DestinationCidrBlock: '0.0.0.0/0'
      GatewayId: !Ref InternetGateway
```

The export would allow the much cleaner:

```yaml
Parameters:
  ParentVPCStack:
    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
    Type: String
Resources:
  NatToInternetRoute:
    Type: 'AWS::EC2::Route'
    Properties:
      RouteTableId: !Ref NatToInternetRouteTable
      DestinationCidrBlock: '0.0.0.0/0'
      GatewayId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-InternetGateway'}
```