### PR TITLE
[Improvement] security/auth-proxy-ha-github-orga - Update OAuth2 Proxy to 5.1.0

### DIFF
--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -721,7 +721,7 @@ Resources:
                 # Short-Description: Start daemon at boot time
                 # Description:       Enable service provided by daemon.
                 ### END INIT INFO
-                dir="/opt/oauth2_proxy/oauth2_proxy-v5.0.0.linux-amd64.go1.13.6"
+                dir="/opt/oauth2_proxy/oauth2_proxy-v5.1.0.linux-amd64.go1.14"
                 cmd="./oauth2_proxy -config=/etc/oauth2_proxy.cfg"
                 user="oauth2_proxy"
                 name=`basename $0`

--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -673,7 +673,7 @@ Resources:
           users:
             oauth2_proxy: {}
           sources:
-            /opt/oauth2_proxy: 'https://github.com/pusher/oauth2_proxy/releases/download/v5.0.0/oauth2_proxy-v5.0.0.linux-amd64.go1.13.6.tar.gz'
+            /opt/oauth2_proxy: 'https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v5.1.0/oauth2_proxy-v5.1.0.linux-amd64.go1.14.tar.gz'
           packages:
             yum:
               nginx: []


### PR DESCRIPTION
https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v5.1.0