### PR TITLE
[Improvement] state/rds-postgres - Add support for parameter and option groups

### DIFF
--- a/state/rds-postgres.yaml
+++ b/state/rds-postgres.yaml
@@ -38,6 +38,8 @@ Metadata:
       - DBMasterUsername
       - DBMasterUserPassword
       - DBMultiAZ
+      - DBOptionGroupName
+      - DBParameterGroupName
       - SubDomainNameWithDot
       - PreferredBackupWindow
       - PreferredMaintenanceWindow
@@ -103,6 +105,10 @@ Parameters:
     Type: String
     Default: true
     AllowedValues: [true, false]
+  DBOptionGroupName:
+    Description: 'The name of an existing DB option group or a reference to an AWS::RDS::OptionGroup resource created in the template.'
+    Type: String
+    Default: ''
   DBParameterGroupName:
     Description: 'The name of an existing DB parameter group or a reference to an AWS::RDS::DBParameterGroup resource created in the template.'
     Type: String
@@ -135,6 +141,7 @@ Conditions:
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
+  HasDBOptionGroupName: !Not [!Equals [!Ref DBOptionGroupName, '']]
   HasDBParameterGroupName: !Not [!Equals [!Ref DBParameterGroupName, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
 Resources:
@@ -187,6 +194,7 @@ Resources:
       CopyTagsToSnapshot: true
       DBInstanceClass: !Ref DBInstanceClass
       DBName: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBName]
+      DBParameterGroupName: !If [HasDBParameterGroupName, !Ref DBParameterGroupName, !Ref 'AWS::NoValue']
       DBSnapshotIdentifier: !If [HasDBSnapshotIdentifier, !Ref DBSnapshotIdentifier, !Ref 'AWS::NoValue']
       DBSubnetGroupName: !Ref DBSubnetGroup
       EnableIAMDatabaseAuthentication: !Ref EnableIAMDatabaseAuthentication
@@ -196,7 +204,7 @@ Resources:
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
       MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
       MultiAZ: !Ref DBMultiAZ
-      DBParameterGroupName: !If [HasDBParameterGroupName, !Ref DBParameterGroupName, !Ref 'AWS::NoValue']
+      OptionGroupName: !If [HasDBOptionGroupName, !Ref DBOptionGroupName, !Ref 'AWS::NoValue']
       PreferredBackupWindow: !Ref PreferredBackupWindow
       PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow
       StorageType: gp2

--- a/state/rds-postgres.yaml
+++ b/state/rds-postgres.yaml
@@ -103,6 +103,10 @@ Parameters:
     Type: String
     Default: true
     AllowedValues: [true, false]
+  DBParameterGroupName:
+    Description: 'The name of an existing DB parameter group or a reference to an AWS::RDS::DBParameterGroup resource created in the template.'
+    Type: String
+    Default: ''
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
@@ -131,6 +135,7 @@ Conditions:
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
+  HasDBParameterGroupName: !Not [!Equals [!Ref DBParameterGroupName, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
 Resources:
   RecordSet:
@@ -191,6 +196,7 @@ Resources:
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
       MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
       MultiAZ: !Ref DBMultiAZ
+      DBParameterGroupName: !If [HasDBParameterGroupName, !Ref DBParameterGroupName, !Ref 'AWS::NoValue']
       PreferredBackupWindow: !Ref PreferredBackupWindow
       PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow
       StorageType: gp2


### PR DESCRIPTION
If you want to [force_ssl](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL.Requiring) on RDS Postgres, you have to do so by providing a `DBParameterGroup`.  This patch add the option to pass such a group value (with the backwards-compatible default) to the `state/rds-postgres` template.

Obviously, this would work with any parameter group (even those unrelated to `force_ssl`), but here's an example with `force_ssl`:

```
  ForceSSLParameterGroup:
    Type: 'AWS::RDS::DBParameterGroup'
    Properties:
      Description: 'Applies rds.force_ssl to pgSQL servers.'
      Family: 'postgres10'
      Parameters:
        rds.force_ssl: '1'
  Database:
    Type: 'AWS::CloudFormation::Stack'
    Properties:
      Parameters:
        ...
        DBParameterGroupName: !Ref ForceSSLParameterGroup
      TemplateURL: './aws-cf-templates/state/rds-postgres.yaml'
```
