### PR TITLE
[Bug Fix] security/auth-proxy-ha-github-orga - update oauth2_proxy to…

### DIFF
--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -731,7 +731,7 @@ Resources:
                 client_secret = "${GitHubClientSecret}"
                 cookie_secret = "${CookieSecret}"
                 provider = "github"
-                github-team = "${GitHubOrganization}"
+                github_org = "${GitHubOrganization}"
               mode: '000644'
               owner: root
               group: root


### PR DESCRIPTION
… correctly authenticate by organisation

This template does not behave as intended due to a config file bug.

As described at https://oauth2-proxy.github.io/oauth2-proxy/configuration#config-file, the correct configuration item should be `github_org`. Also, `github-team` is invalid anyway due to a hyphen instead of an underscore, and seems to be totally ignored. As a result, the template allows *any* authenticated GitHub user to authenticate to the proxy.

This example is with two different users. One which is *not* in the organisation supplied as the `GitHubOrganization` parameter, and one which is.


#### Before 
```
# user *not* in the organisation
[2020/05/06 02:07:56] [github.go:352] got 200 from "https://api.github.com/user" 
10.0.77.153 - INVALID@example.com [2020/05/06 02:07:56] [AuthSuccess] Authenticated via OAuth2: Session{email:INVALID@example.com user:INVALID token:true created:2020-05-06 02:07:55.945921093 +0000 UTC m=+1626180.308220238}

# user in the organisation obviously succeeds as well
```

#### After
```
# user *not* in the organisation
[2020/05/06 02:27:06] [github.go:352] got 200 from "https://api.github.com/user" 
10.0.77.153 - - [2020/05/06 02:27:06] [AuthFailure] Invalid authentication via OAuth2: unauthorized
[2020/05/06 02:27:10] [github.go:128] Missing Organization:"MYORG" in []
```

```
# user in the organisation
[2020/05/06 02:27:28] [github.go:352] got 200 from "https://api.github.com/user" 
[2020/05/06 02:27:33] [github.go:122] Found Github Organization: "MYORG"
10.0.2.39 - VALID@example.com [2020/05/06 02:27:34] [AuthSuccess] Authenticated via OAuth2: Session{email:VALID@example.com user:VALID token:true created:2020-05-06 02:27:33.193486366 +0000 UTC m=+157.212186929}
```