### PR TITLE
Use regional domain name of S3 bucket in CloudFront

### DIFF
--- a/static-website/static-website.yaml
+++ b/static-website/static-website.yaml
@@ -240,7 +240,7 @@ Resources:
         IPV6Enabled: true
         Logging: !If [HasS3Bucket, {Bucket: {'Fn::ImportValue': !Sub '${ParentS3StackAccessLog}-BucketDomainName'}, Prefix: !Ref 'AWS::StackName'}, !Ref 'AWS::NoValue']
         Origins:
-        - DomainName: !GetAtt 'S3Bucket.DomainName'
+        - DomainName: !GetAtt 'S3Bucket.RegionalDomainName'
           Id: s3origin
           S3OriginConfig:
             OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}'


### PR DESCRIPTION
S3 buckets have two domain names: a global and a regional one. Buckets which have been just created may lead to a redirect when using the global domain name. The static website would not work then unless you wait some hours. The regional domain name works immediately.