### PR TITLE
[Bug Fix] operations/*-access-logs-anonymizer - Improve error handling when file was already anonymized

### DIFF
--- a/operations/alb-access-logs-anonymizer.yaml
+++ b/operations/alb-access-logs-anonymizer.yaml
@@ -59,6 +59,14 @@ Resources:
           Statement:
           - Effect: Allow
             Action:
+            - 's3:ListBucket'
+            - 's3:ListBucketVersions'
+            Resource: !Sub
+            - 'arn:${Partition}:s3:::${BucketName}'
+            - Partition: !Ref 'AWS::Partition'
+              BucketName: {'Fn::ImportValue': !Sub '${ParentS3Stack}-BucketName'}
+          - Effect: Allow
+            Action:
             - 's3:GetObject'
             - 's3:GetObjectVersion'
             - 's3:PutObject'
@@ -127,6 +135,7 @@ Resources:
           }
 
           async function process(record) {
+            const anonymizedKey = record.s3.object.key.slice(0, -2) + 'anonymized.gz';
             let chunk = Buffer.alloc(0);
             const transform = (currentChunk, encoding, callback) => {
               chunk = Buffer.concat([chunk, currentChunk]);
@@ -153,21 +162,55 @@ Resources:
             if ('versionId' in record.s3.object) {
               params.VersionId = record.s3.object.versionId;
             }
-            const body = s3.getObject(params).createReadStream()
-              .pipe(zlib.createGunzip())
-              .pipe(new stream.Transform({
-                transform
-              }))
-              .pipe(zlib.createGzip());
-            await s3.upload({
-              Bucket: record.s3.bucket.name,
-              Key: record.s3.object.key.slice(0, -2) + 'anonymized.gz',
-              Body: body
-            }).promise();
-            if (chunk.length > 0) {
-              throw new Error('file was not read completly');
-            }
-            return s3.deleteObject(params).promise();
+            return new Promise((resolve, reject) => {
+              const body = stream.pipeline(
+                s3.getObject(params).createReadStream(),
+                zlib.createGunzip(),
+                new stream.Transform({
+                  transform
+                }),
+                zlib.createGzip(),
+                () => {}
+              );
+              s3.upload({
+                Bucket: record.s3.bucket.name,
+                Key: anonymizedKey,
+                Body: body
+              }, (err) => {
+                if (err) {
+                  if (err) {
+                    if (err.code === 'NoSuchKey') {
+                      console.log('original no longer exist, check for anonymized object.')
+                      s3.headObject({
+                        Bucket: record.s3.bucket.name,
+                        Key: anonymizedKey
+                      }, (err) => {
+                        if (err) {
+                          reject(err);
+                        } else {
+                          // original already processed
+                          resolve();
+                        }
+                      });
+                    } else {
+                      reject(err);
+                    }
+                  }
+                } else {
+                  if (chunk.length > 0) {
+                    reject(new Error('file was not read completly'));
+                  } else {
+                    s3.deleteObject(params, (err) => {
+                      if (err) {
+                        reject(err);
+                      } else {
+                        resolve();
+                      }
+                    });
+                  }
+                }
+              });
+            });
           }
 
           exports.handler = async (event) => {

--- a/operations/cloudfront-access-logs-anonymizer.yaml
+++ b/operations/cloudfront-access-logs-anonymizer.yaml
@@ -59,6 +59,14 @@ Resources:
           Statement:
           - Effect: Allow
             Action:
+            - 's3:ListBucket'
+            - 's3:ListBucketVersions'
+            Resource: !Sub
+            - 'arn:${Partition}:s3:::${BucketName}'
+            - Partition: !Ref 'AWS::Partition'
+              BucketName: {'Fn::ImportValue': !Sub '${ParentS3Stack}-BucketName'}
+          - Effect: Allow
+            Action:
             - 's3:GetObject'
             - 's3:GetObjectVersion'
             - 's3:PutObject'
@@ -128,6 +136,7 @@ Resources:
           }
 
           async function process(record) {
+            const anonymizedKey = record.s3.object.key.slice(0, -2) + 'anonymized.gz';
             let chunk = Buffer.alloc(0);
             const transform = (currentChunk, encoding, callback) => {
               chunk = Buffer.concat([chunk, currentChunk]);
@@ -154,21 +163,55 @@ Resources:
             if ('versionId' in record.s3.object) {
               params.VersionId = record.s3.object.versionId;
             }
-            const body = s3.getObject(params).createReadStream()
-              .pipe(zlib.createGunzip())
-              .pipe(new stream.Transform({
-                transform
-              }))
-              .pipe(zlib.createGzip());
-            await s3.upload({
-              Bucket: record.s3.bucket.name,
-              Key: record.s3.object.key.slice(0, -2) + 'anonymized.gz',
-              Body: body
-            }).promise();
-            if (chunk.length > 0) {
-              throw new Error('file was not read completly');
-            }
-            return s3.deleteObject(params).promise();
+            return new Promise((resolve, reject) => {
+              const body = stream.pipeline(
+                s3.getObject(params).createReadStream(),
+                zlib.createGunzip(),
+                new stream.Transform({
+                  transform
+                }),
+                zlib.createGzip(),
+                () => {}
+              );
+              s3.upload({
+                Bucket: record.s3.bucket.name,
+                Key: anonymizedKey,
+                Body: body
+              }, (err) => {
+                if (err) {
+                  if (err) {
+                    if (err.code === 'NoSuchKey') {
+                      console.log('original no longer exist, check for anonymized object.')
+                      s3.headObject({
+                        Bucket: record.s3.bucket.name,
+                        Key: anonymizedKey
+                      }, (err) => {
+                        if (err) {
+                          reject(err);
+                        } else {
+                          // original already processed
+                          resolve();
+                        }
+                      });
+                    } else {
+                      reject(err);
+                    }
+                  }
+                } else {
+                  if (chunk.length > 0) {
+                    reject(new Error('file was not read completly'));
+                  } else {
+                    s3.deleteObject(params, (err) => {
+                      if (err) {
+                        reject(err);
+                      } else {
+                        resolve();
+                      }
+                    });
+                  }
+                }
+              });
+            });
           }
 
           exports.handler = async (event) => {


### PR DESCRIPTION
If a original file was anoymized but the event was dispatched twice a NoSuchKey error was thrown (AccessDenied to be more pricise but I fixed that as well).

Now, if we receive a NoSuchKey error for the original key, we check if the anonymized key already exist.
If yes, done. Work is already done.
If no, throw error again.

I also fixed an issue with they way errors are not "piped" thrhough when connection streams with .pipe().