### PR TITLE
[Security] * - Update Amazon Linux AMIs

### DIFF
--- a/ec2/README.md
+++ b/ec2/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/ec2/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200520.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200722.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/ec2/al2-mutable-private.yaml
+++ b/ec2/al2-mutable-private.yaml
@@ -196,9 +196,11 @@ Parameters:
     Description: 'Version of Amazon Linux 2 to boot from the first time (ignored if RestoreImageId is set; select the latest version for new stacks; OS updates are enabled to patch the system).'
     Type: String
     Default: '20191217.0'
-    AllowedValues: ['20200520.1', '20200406.0', '20200304.0', '20200207.1', '20191217.0']
+    AllowedValues: ['20200722.0', '20200520.1', '20200406.0', '20200304.0', '20200207.1', '20191217.0']
 Mappings:
   VersionMap:
+    '20200722.0':
+      Map: RegionMap202007220
     '20200520.1':
       Map: RegionMap202005201
     '20200406.0':
@@ -209,6 +211,47 @@ Mappings:
       Map: RegionMap202002071
     '20191217.0':
       Map: RegionMap201912170
+  RegionMap202007220:
+    'af-south-1':
+      AMI: 'ami-08c9d9528020000ac'
+    'eu-north-1':
+      AMI: 'ami-039609244d2810a6b'
+    'ap-south-1':
+      AMI: 'ami-0ebc1ac48dfd14136'
+    'eu-west-3':
+      AMI: 'ami-093fa4c538885becf'
+    'eu-west-2':
+      AMI: 'ami-0a13d44dccf1f5cf6'
+    'eu-south-1':
+      AMI: 'ami-0533a9871112d2d51'
+    'eu-west-1':
+      AMI: 'ami-07d9160fa81ccffb5'
+    'ap-northeast-2':
+      AMI: 'ami-0bd7691bf6470fe9c'
+    'me-south-1':
+      AMI: 'ami-01f41d49c363da2ad'
+    'ap-northeast-1':
+      AMI: 'ami-0cc75a8978fbbc969'
+    'sa-east-1':
+      AMI: 'ami-018ccfb6b4745882a'
+    'ca-central-1':
+      AMI: 'ami-013d1df4bcea6ba95'
+    'ap-east-1':
+      AMI: 'ami-47317236'
+    'ap-southeast-1':
+      AMI: 'ami-0cd31be676780afa7'
+    'ap-southeast-2':
+      AMI: 'ami-0ded330691a314693'
+    'eu-central-1':
+      AMI: 'ami-0c115dbd34c69a004'
+    'us-east-1':
+      AMI: 'ami-02354e95b39ca8dec'
+    'us-east-2':
+      AMI: 'ami-07c8bc5c1ce9598c3'
+    'us-west-1':
+      AMI: 'ami-05655c267c89566dd'
+    'us-west-2':
+      AMI: 'ami-0873b46c45c11058d'
   RegionMap202005201:
     'af-south-1':
       AMI: 'ami-0ec47ddb564d75b64'

--- a/ec2/al2-mutable-public.yaml
+++ b/ec2/al2-mutable-public.yaml
@@ -196,9 +196,11 @@ Parameters:
     Description: 'Version of Amazon Linux 2 to boot from the first time (ignored if RestoreImageId is set; select the latest version for new stacks; OS updates are enabled to patch the system).'
     Type: String
     Default: '20191217.0'
-    AllowedValues: ['20200520.1', '20200406.0', '20200304.0', '20200207.1', '20191217.0']
+    AllowedValues: ['20200722.0', '20200520.1', '20200406.0', '20200304.0', '20200207.1', '20191217.0']
 Mappings:
   VersionMap:
+    '20200722.0':
+      Map: RegionMap202007220
     '20200520.1':
       Map: RegionMap202005201
     '20200406.0':
@@ -209,6 +211,47 @@ Mappings:
       Map: RegionMap202002071
     '20191217.0':
       Map: RegionMap201912170
+  RegionMap202007220:
+    'af-south-1':
+      AMI: 'ami-08c9d9528020000ac'
+    'eu-north-1':
+      AMI: 'ami-039609244d2810a6b'
+    'ap-south-1':
+      AMI: 'ami-0ebc1ac48dfd14136'
+    'eu-west-3':
+      AMI: 'ami-093fa4c538885becf'
+    'eu-west-2':
+      AMI: 'ami-0a13d44dccf1f5cf6'
+    'eu-south-1':
+      AMI: 'ami-0533a9871112d2d51'
+    'eu-west-1':
+      AMI: 'ami-07d9160fa81ccffb5'
+    'ap-northeast-2':
+      AMI: 'ami-0bd7691bf6470fe9c'
+    'me-south-1':
+      AMI: 'ami-01f41d49c363da2ad'
+    'ap-northeast-1':
+      AMI: 'ami-0cc75a8978fbbc969'
+    'sa-east-1':
+      AMI: 'ami-018ccfb6b4745882a'
+    'ca-central-1':
+      AMI: 'ami-013d1df4bcea6ba95'
+    'ap-east-1':
+      AMI: 'ami-47317236'
+    'ap-southeast-1':
+      AMI: 'ami-0cd31be676780afa7'
+    'ap-southeast-2':
+      AMI: 'ami-0ded330691a314693'
+    'eu-central-1':
+      AMI: 'ami-0c115dbd34c69a004'
+    'us-east-1':
+      AMI: 'ami-02354e95b39ca8dec'
+    'us-east-2':
+      AMI: 'ami-07c8bc5c1ce9598c3'
+    'us-west-1':
+      AMI: 'ami-05655c267c89566dd'
+    'us-west-2':
+      AMI: 'ami-0873b46c45c11058d'
   RegionMap202005201:
     'af-south-1':
       AMI: 'ami-0ec47ddb564d75b64'

--- a/ec2/ec2-auto-recovery.yaml
+++ b/ec2/ec2-auto-recovery.yaml
@@ -157,45 +157,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/ecs/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-ecs-hvm-2.0.20200603-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  ECSAMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-ecs-hvm-2.0.20200723-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  ECSAMI: '$ami'\n"; done
 ```

--- a/ecs/cluster-cost-optimized.yaml
+++ b/ecs/cluster-cost-optimized.yaml
@@ -166,42 +166,46 @@ Parameters:
     MaxValue: 3600
 Mappings:
   RegionMap:
+    'af-south-1':
+      ECSAMI: 'ami-0f91be324f8d88adb'
     'eu-north-1':
-      ECSAMI: 'ami-0639f978e5b88a840'
+      ECSAMI: 'ami-04acfa2afd4604b14'
     'ap-south-1':
-      ECSAMI: 'ami-0a03968949ee4e012'
+      ECSAMI: 'ami-05d6edad5808a4739'
     'eu-west-3':
-      ECSAMI: 'ami-0b700aef0f223def9'
+      ECSAMI: 'ami-05560d522ac23788b'
     'eu-west-2':
-      ECSAMI: 'ami-03ec263c71e44528d'
+      ECSAMI: 'ami-02254c861b8371869'
+    'eu-south-1':
+      ECSAMI: 'ami-0c53a68c1ed9e0ec7'
     'eu-west-1':
-      ECSAMI: 'ami-09cec0d91e6d220ea'
+      ECSAMI: 'ami-0bb01c7d2705a4800'
     'ap-northeast-2':
-      ECSAMI: 'ami-0750fd52026129ec6'
+      ECSAMI: 'ami-029df54b84ab8240f'
     'me-south-1':
-      ECSAMI: 'ami-0d2020f7eaca12fa0'
+      ECSAMI: 'ami-06d4ebd232978cc42'
     'ap-northeast-1':
-      ECSAMI: 'ami-00e177b8d879d5d3f'
+      ECSAMI: 'ami-0763fff45988661c8'
     'sa-east-1':
-      ECSAMI: 'ami-05b1add1a0c31be07'
+      ECSAMI: 'ami-0474a590e95647451'
     'ca-central-1':
-      ECSAMI: 'ami-00f6d6e2711b7adbe'
+      ECSAMI: 'ami-092262e997a1ab27b'
     'ap-east-1':
-      ECSAMI: 'ami-0a75552e697a7b2aa'
+      ECSAMI: 'ami-0bba587b67ceaddea'
     'ap-southeast-1':
-      ECSAMI: 'ami-0689726e1a700ed66'
+      ECSAMI: 'ami-0bd1daf5da8a9a903'
     'ap-southeast-2':
-      ECSAMI: 'ami-0e6b68880cc94cf09'
+      ECSAMI: 'ami-0a7c4f7f17d3eecbc'
     'eu-central-1':
-      ECSAMI: 'ami-0fe4cfe8d04ec091e'
+      ECSAMI: 'ami-01b521fb7540d9996'
     'us-east-1':
-      ECSAMI: 'ami-00f69adbdc780866c'
+      ECSAMI: 'ami-007cd1678c6286a05'
     'us-east-2':
-      ECSAMI: 'ami-044bf85e844eddde5'
+      ECSAMI: 'ami-06e05a843071324d1'
     'us-west-1':
-      ECSAMI: 'ami-014ee82610857fa9a'
+      ECSAMI: 'ami-00271233a1ebb9161'
     'us-west-2':
-      ECSAMI: 'ami-088dbc54f17f8a1a2'
+      ECSAMI: 'ami-01e1d12a048e67ed2'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -194,45 +194,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      ECSAMI: 'ami-0f46c3b6657359999'
+      ECSAMI: 'ami-0f91be324f8d88adb'
     'eu-north-1':
-      ECSAMI: 'ami-08163d891cc05881a'
+      ECSAMI: 'ami-04acfa2afd4604b14'
     'ap-south-1':
-      ECSAMI: 'ami-0c20a67db6e1c7258'
+      ECSAMI: 'ami-05d6edad5808a4739'
     'eu-west-3':
-      ECSAMI: 'ami-00a12748018f55f56'
+      ECSAMI: 'ami-05560d522ac23788b'
     'eu-west-2':
-      ECSAMI: 'ami-038863f4c20d2d63d'
+      ECSAMI: 'ami-02254c861b8371869'
     'eu-south-1':
-      ECSAMI: 'ami-077d25730f36e8a2f'
+      ECSAMI: 'ami-0c53a68c1ed9e0ec7'
     'eu-west-1':
-      ECSAMI: 'ami-0cf112c4c967e0437'
+      ECSAMI: 'ami-0bb01c7d2705a4800'
     'ap-northeast-2':
-      ECSAMI: 'ami-0a42b1e2c5f22035c'
+      ECSAMI: 'ami-029df54b84ab8240f'
     'me-south-1':
-      ECSAMI: 'ami-0c96102b13194fa66'
+      ECSAMI: 'ami-06d4ebd232978cc42'
     'ap-northeast-1':
-      ECSAMI: 'ami-0471ea40c46b4325d'
+      ECSAMI: 'ami-0763fff45988661c8'
     'sa-east-1':
-      ECSAMI: 'ami-0e720f8542a11d10b'
+      ECSAMI: 'ami-0474a590e95647451'
     'ca-central-1':
-      ECSAMI: 'ami-01a7c134a00678ad6'
+      ECSAMI: 'ami-092262e997a1ab27b'
     'ap-east-1':
-      ECSAMI: 'ami-096f6010959d0d538'
+      ECSAMI: 'ami-0bba587b67ceaddea'
     'ap-southeast-1':
-      ECSAMI: 'ami-00100469ca2a34fa3'
+      ECSAMI: 'ami-0bd1daf5da8a9a903'
     'ap-southeast-2':
-      ECSAMI: 'ami-02446908683d78c79'
+      ECSAMI: 'ami-0a7c4f7f17d3eecbc'
     'eu-central-1':
-      ECSAMI: 'ami-08c4be469fbdca0fa'
+      ECSAMI: 'ami-01b521fb7540d9996'
     'us-east-1':
-      ECSAMI: 'ami-0b22c910bce7178b6'
+      ECSAMI: 'ami-007cd1678c6286a05'
     'us-east-2':
-      ECSAMI: 'ami-0b29e28ad09b4e536'
+      ECSAMI: 'ami-06e05a843071324d1'
     'us-west-1':
-      ECSAMI: 'ami-0560993025898e8e8'
+      ECSAMI: 'ami-00271233a1ebb9161'
     'us-west-2':
-      ECSAMI: 'ami-0633e2a3c7135c18a'
+      ECSAMI: 'ami-01e1d12a048e67ed2'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/jenkins/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200520.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200722.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -211,45 +211,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasZeroAgents: !Equals [!Ref AgentMinSize, '0']
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/jenkins/jenkins2-ha.yaml
+++ b/jenkins/jenkins2-ha.yaml
@@ -158,45 +158,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/security/README.md
+++ b/security/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/security/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200520.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200722.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -132,45 +132,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -9,10 +9,10 @@ To update the region map execute the following lines in your terminal:
 
 #### AMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200520.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200722.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 #### NATAMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn-ami-vpc-nat-2018.03.0.20200602.1-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  NATAMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn-ami-vpc-nat-2018.03.0.20200716.0-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  NATAMI: '$ami'\n"; done
 ```

--- a/vpc/vpc-nat-instance.yaml
+++ b/vpc/vpc-nat-instance.yaml
@@ -91,45 +91,45 @@ Parameters:
 Mappings:
   RegionMap: # TODO update to Amazon Linux 2 (don't forget to adjust awslogs config as well)
     'af-south-1':
-      NATAMI: 'ami-0d00f6c62c7390506'
+      NATAMI: 'ami-068bf79dfb2bc0474'
     'eu-north-1':
-      NATAMI: 'ami-0b757d5486b786f2c'
+      NATAMI: 'ami-04d58d9ed10c893b4'
     'ap-south-1':
-      NATAMI: 'ami-01c30c99d674913a6'
+      NATAMI: 'ami-0240522d3ed3ae5ec'
     'eu-west-3':
-      NATAMI: 'ami-099e6df42675353df'
+      NATAMI: 'ami-0966fbf8a2a71fa29'
     'eu-west-2':
-      NATAMI: 'ami-0270a936dc5f81ce1'
+      NATAMI: 'ami-0e430e165487ea925'
     'eu-south-1':
-      NATAMI: 'ami-02dc5e921e12ea8a1'
+      NATAMI: 'ami-06a4980f3677a1716'
     'eu-west-1':
-      NATAMI: 'ami-08b3d07493aa99e23'
+      NATAMI: 'ami-032df3592cc862884'
     'ap-northeast-2':
-      NATAMI: 'ami-03c996dd63a01a39d'
+      NATAMI: 'ami-07bed51507c769843'
     'me-south-1':
-      NATAMI: 'ami-042de4fad51e42c65'
+      NATAMI: 'ami-0ecaad98428393640'
     'ap-northeast-1':
-      NATAMI: 'ami-02d6b7c8e52e51c09'
+      NATAMI: 'ami-0481e994e8d29db03'
     'sa-east-1':
-      NATAMI: 'ami-01d6581b19291b36e'
+      NATAMI: 'ami-04cb968946195a4bc'
     'ca-central-1':
-      NATAMI: 'ami-02a1ff0e9b1a6d29c'
+      NATAMI: 'ami-062bcf715d048ae22'
     'ap-east-1':
-      NATAMI: 'ami-852f6ff4'
+      NATAMI: 'ami-851053f4'
     'ap-southeast-1':
-      NATAMI: 'ami-0b23d540c47ce8960'
+      NATAMI: 'ami-09a263088286e87d1'
     'ap-southeast-2':
-      NATAMI: 'ami-0a89e65344dd36759'
+      NATAMI: 'ami-083dc6c6eb8ac18a8'
     'eu-central-1':
-      NATAMI: 'ami-01cce56dd6e02ebf5'
+      NATAMI: 'ami-0a3d79918c0b64aac'
     'us-east-1':
-      NATAMI: 'ami-05b76e217ebb8b2c2'
+      NATAMI: 'ami-01ef31f9f39c5aaed'
     'us-east-2':
-      NATAMI: 'ami-07284cf6f64c447ee'
+      NATAMI: 'ami-06064740484d375de'
     'us-west-1':
-      NATAMI: 'ami-023fe09ce43d87de4'
+      NATAMI: 'ami-0e365eb5252ebe986'
     'us-west-2':
-      NATAMI: 'ami-0b7fea0bbdcbe0157'
+      NATAMI: 'ami-0fcc6101b7f2370b9'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/vpc/vpc-ssh-bastion.yaml
+++ b/vpc/vpc-ssh-bastion.yaml
@@ -83,45 +83,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/vpc/vpc-vpn-bastion.yaml
+++ b/vpc/vpc-vpn-bastion.yaml
@@ -125,45 +125,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref IAMUserSSHAccess, 'true']

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -8,7 +8,7 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/wordpress
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200520.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20200722.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 ### Load Test

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -183,45 +183,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref WebServerKeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref WebServerIAMUserSSHAccess, 'true']

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -183,45 +183,45 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0ec47ddb564d75b64'
+      AMI: 'ami-08c9d9528020000ac'
     'eu-north-1':
-      AMI: 'ami-04697c9bb5d6135a2'
+      AMI: 'ami-039609244d2810a6b'
     'ap-south-1':
-      AMI: 'ami-0447a12f28fddb066'
+      AMI: 'ami-0ebc1ac48dfd14136'
     'eu-west-3':
-      AMI: 'ami-01c72e187b357583b'
+      AMI: 'ami-093fa4c538885becf'
     'eu-west-2':
-      AMI: 'ami-032598fcc7e9d1c7a'
+      AMI: 'ami-0a13d44dccf1f5cf6'
     'eu-south-1':
-      AMI: 'ami-0f9b9a8cf93d838d0'
+      AMI: 'ami-0533a9871112d2d51'
     'eu-west-1':
-      AMI: 'ami-0ea3405d2d2522162'
+      AMI: 'ami-07d9160fa81ccffb5'
     'ap-northeast-2':
-      AMI: 'ami-01af223aa7f274198'
+      AMI: 'ami-0bd7691bf6470fe9c'
     'me-south-1':
-      AMI: 'ami-01b31491b74045c0c'
+      AMI: 'ami-01f41d49c363da2ad'
     'ap-northeast-1':
-      AMI: 'ami-0a1c2ec61571737db'
+      AMI: 'ami-0cc75a8978fbbc969'
     'sa-east-1':
-      AMI: 'ami-0477a95397a9154b3'
+      AMI: 'ami-018ccfb6b4745882a'
     'ca-central-1':
-      AMI: 'ami-0f75c2980c6a5851d'
+      AMI: 'ami-013d1df4bcea6ba95'
     'ap-east-1':
-      AMI: 'ami-49bbfa38'
+      AMI: 'ami-47317236'
     'ap-southeast-1':
-      AMI: 'ami-0615132a0f36d24f4'
+      AMI: 'ami-0cd31be676780afa7'
     'ap-southeast-2':
-      AMI: 'ami-088ff0e3bde7b3fdf'
+      AMI: 'ami-0ded330691a314693'
     'eu-central-1':
-      AMI: 'ami-0a02ee601d742e89f'
+      AMI: 'ami-0c115dbd34c69a004'
     'us-east-1':
-      AMI: 'ami-09d95fab7fff3776c'
+      AMI: 'ami-02354e95b39ca8dec'
     'us-east-2':
-      AMI: 'ami-026dea5602e368e96'
+      AMI: 'ami-07c8bc5c1ce9598c3'
     'us-west-1':
-      AMI: 'ami-04e59c05167ea7bd5'
+      AMI: 'ami-05655c267c89566dd'
     'us-west-2':
-      AMI: 'ami-0e34e7b9ca0ace12d'
+      AMI: 'ami-0873b46c45c11058d'
 Conditions:
   HasKeyName: !Not [!Equals [!Ref WebServerKeyName, '']]
   HasIAMUserSSHAccess: !Equals [!Ref WebServerIAMUserSSHAccess, 'true']


### PR DESCRIPTION
* AL2 to 20200520.1
* AL2 ECS to 20200603
* AL1 NAT 2018.03.0 to 20200602.1