### PR TITLE
Security Group Outputs

### DIFF
--- a/state/documentdb.yaml
+++ b/state/documentdb.yaml
@@ -289,3 +289,8 @@ Outputs:
     Value: !GetAtt 'Cluster.ReadEndpoint'
     Export:
       Name: !Sub '${AWS::StackName}-ReadEndpoint'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to Document DB.'
+    Value: !Ref SecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/elasticache-memcached.yaml
+++ b/state/elasticache-memcached.yaml
@@ -291,7 +291,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
   SecurityGroupId:
-    Description: 'The security group used to manage access to Elasticache Redis.'
+    Description: 'The security group used to manage access to Elasticache Memcached.'
     Value: !Ref SecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/elasticache-memcached.yaml
+++ b/state/elasticache-memcached.yaml
@@ -290,3 +290,8 @@ Outputs:
     Value: !GetAtt 'CacheCluster.ConfigurationEndpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to Elasticache Redis.'
+    Value: !Ref SecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/elasticache-redis.yaml
+++ b/state/elasticache-redis.yaml
@@ -369,3 +369,8 @@ Outputs:
     Value: !GetAtt 'ReplicationGroup.PrimaryEndPoint.Port'
     Export:
       Name: !Sub '${AWS::StackName}-PrimaryEndPointPort'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to Elasticache Redis.'
+    Value: !Ref SecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/elasticsearch.yaml
+++ b/state/elasticsearch.yaml
@@ -507,3 +507,8 @@ Outputs:
     Value: !GetAtt 'ElasticsearchDomain.DomainEndpoint'
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to Elasticache Redis.'
+    Value: !Ref SecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/elasticsearch.yaml
+++ b/state/elasticsearch.yaml
@@ -508,7 +508,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
   SecurityGroupId:
-    Description: 'The security group used to manage access to Elasticache Redis.'
+    Description: 'The security group used to manage access to Elasticsearch.'
     Value: !Ref SecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-aurora-serverless-postgres.yaml
+++ b/state/rds-aurora-serverless-postgres.yaml
@@ -248,3 +248,8 @@ Outputs:
     Value: !GetAtt 'DBCluster.Endpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to RDS Aurora.'
+    Value: !Ref ClusterSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-aurora-serverless-postgres.yaml
+++ b/state/rds-aurora-serverless-postgres.yaml
@@ -249,7 +249,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
   SecurityGroupId:
-    Description: 'The security group used to manage access to RDS Aurora.'
+    Description: 'The security group used to manage access to RDS Aurora Serverless Postgres.'
     Value: !Ref ClusterSecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-aurora-serverless.yaml
+++ b/state/rds-aurora-serverless.yaml
@@ -256,7 +256,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
   SecurityGroupId:
-    Description: 'The security group used to manage access to Elasticache Redis.'
+    Description: 'The security group used to manage access to RDS Aurora Serverless.'
     Value: !Ref ClusterSecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-aurora-serverless.yaml
+++ b/state/rds-aurora-serverless.yaml
@@ -255,3 +255,8 @@ Outputs:
     Value: !GetAtt 'DBCluster.Endpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to Elasticache Redis.'
+    Value: !Ref ClusterSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -464,3 +464,8 @@ Outputs:
     Value: !GetAtt 'DBCluster.ReadEndpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-ReadDNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to Elasticache Redis.'
+    Value: !Ref ClusterSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -465,7 +465,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-ReadDNSName'
   SecurityGroupId:
-    Description: 'The security group used to manage access to Elasticache Redis.'
+    Description: 'The security group used to manage access to RDS Aurora.'
     Value: !Ref ClusterSecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-mysql.yaml
+++ b/state/rds-mysql.yaml
@@ -379,7 +379,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
   SecurityGroupId:
-    Description: 'The security group used to manage access to RDS mysql.'
+    Description: 'The security group used to manage access to RDS MySQL.'
     Value: !Ref DatabaseSecurityGroup
     Export:
       Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-mysql.yaml
+++ b/state/rds-mysql.yaml
@@ -378,3 +378,8 @@ Outputs:
     Value: !GetAtt 'DBInstance.Endpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to RDS mysql.'
+    Value: !Ref DatabaseSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'

--- a/state/rds-postgres.yaml
+++ b/state/rds-postgres.yaml
@@ -378,3 +378,8 @@ Outputs:
     Value: !GetAtt 'DBInstance.Endpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-DNSName'
+  SecurityGroupId:
+    Description: 'The security group used to manage access to RDS Postgres.'
+    Value: !Ref DatabaseSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroupId'


### PR DESCRIPTION
Resolves #456 by exposing the ingress security group for `state/*` templates at `SecurityGroupId` to support advanced networking strategies.

I included the same interface in all of the `state/*` templates that include a Security Group (vs. just `rds-postgres`) for consistency, but I can remove some/all of the rest if there's a reason to prefer to limit the scope.