### PR TITLE
[Improvement] wordpress/wordpress-ha: Enabling RDS Performance Insights

### DIFF
--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -468,6 +468,8 @@ Resources:
       DBSubnetGroupName: !Ref DBSubnetGroup
       MultiAZ: true
       StorageType: gp2
+      EnablePerformanceInsights: true
+      PerformanceInsightsRetentionPeriod: 7
   DatabaseBurstBalanceTooLowAlarm:
     Condition: HasAlertTopic
     Type: 'AWS::CloudWatch::Alarm'


### PR DESCRIPTION
Enabling RDS Performance Insights for Wordpress. RDS Performance Insights is free for 7 day data retention.