### PR TITLE
[Bug Fix] operations/alert: Workaround for SNS delay

### DIFF
--- a/operations/alert.yaml
+++ b/operations/alert.yaml
@@ -130,8 +130,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        # throttlePolicy:
-        #   maxReceivesPerSecond: 1
       Endpoint: !Ref HttpEndpoint
       Protocol: http
       TopicArn: !Ref Topic
@@ -146,8 +144,6 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        # throttlePolicy:
-        #   maxReceivesPerSecond: 1
       Endpoint: !Ref HttpsEndpoint
       Protocol: https
       TopicArn: !Ref Topic

--- a/operations/alert.yaml
+++ b/operations/alert.yaml
@@ -130,8 +130,8 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
+        # throttlePolicy:
+        #   maxReceivesPerSecond: 1
       Endpoint: !Ref HttpEndpoint
       Protocol: http
       TopicArn: !Ref Topic
@@ -146,8 +146,8 @@ Resources:
           numRetries: 100
           numNoDelayRetries: 0
           backoffFunction: exponential
-        throttlePolicy:
-          maxReceivesPerSecond: 1
+        # throttlePolicy:
+        #   maxReceivesPerSecond: 1
       Endpoint: !Ref HttpsEndpoint
       Protocol: https
       TopicArn: !Ref Topic


### PR DESCRIPTION
HTTP/S subscriptions will suffer from huge delays. This is a workaround recommended by AWS. Check out https://cloudonaut.io/loosing-trust-in-aws-sns-broken-for-24-days/ for details.