### PR TITLE
Add Secrets Manager Secret to RDS Aurora Template

### DIFF
--- a/state/documentdb.yaml
+++ b/state/documentdb.yaml
@@ -25,6 +25,7 @@ Metadata:
       - ParentAlertStack
       - ParentBastionStack
       - ParentKmsKeyStack
+      - ParentSecretStack
     - Label:
         default: 'DocumentDB Parameters'
       Parameters:
@@ -56,6 +57,10 @@ Parameters:
     Description: 'Optional Stack name of parent KMS key stack based on security/kms-key.yaml template (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
     Type: String
     Default: ''
+  ParentSecretStack:
+    Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
+    Type: String
+    Default: ''
   BackupRetentionPeriod:
     Description: 'The number of days for which automated backups are retained.'
     Type: Number
@@ -79,10 +84,11 @@ Parameters:
     MaxLength: 63
     Default: master
   MasterUserPassword:
-    Description: 'The password for the master database user. This password can contain any printable ASCII character except forward slash (/), double quote ("), or the "at" symbol (@).'
+    Description: >-
+      'The password for the master database user. This password can contain any printable ASCII character except forward slash (/), double quote ("), or the "at" symbol (@).
+      This will be ignored if ParentSecretStack is used.'
     Type: String
-    MinLength: 8
-    MaxLength: 100
+    AllowedPattern: ^$|^[^@/\"]{8,100}$
     NoEcho: true
   PreferredBackupWindow:
     Description: 'The daily time range (in UTC) during which automated backups are created.'
@@ -105,6 +111,7 @@ Mappings:
     '3.6.0':
       ParameterGroupFamily: 'docdb3.6'
 Conditions:
+  HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
   HasParentKmsKeyStack: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasParentAlertStack: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasParentBastionStack: !Not [!Equals [!Ref ParentBastionStack, '']]
@@ -112,6 +119,13 @@ Conditions:
   HasNotDBClusterParameterGroupName: !Not [!Condition HasDBClusterParameterGroupName]
   HasSnapshotIdentifier: !Not [!Equals [!Ref SnapshotIdentifier, '']]
 Resources:
+  SecretTargetAttachment:
+    Condition: HasSecret
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      TargetId: !Ref Cluster
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
+      TargetType: AWS::DocDB::DBCluster
   DBSubnetGroup:
     Type: 'AWS::DocDB::DBSubnetGroup'
     Properties:
@@ -158,7 +172,13 @@ Resources:
       EngineVersion: !Ref EngineVersion
       KmsKeyId: !If [HasParentKmsKeyStack, {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyId'}, !Ref 'AWS::NoValue']
       MasterUsername: !Ref MasterUsername
-      MasterUserPassword: !Ref MasterUserPassword
+      MasterUserPassword: !If
+      - HasSnapshotIdentifier
+      - !Ref 'AWS::NoValue'
+      - !If
+        - HasSecret
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ":SecretString:password}}"]]}
+        - !Ref MasterUserPassword
       Port: 27017
       PreferredBackupWindow: !Ref PreferredBackupWindow
       PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow

--- a/state/rds-aurora-serverless-postgres.yaml
+++ b/state/rds-aurora-serverless-postgres.yaml
@@ -26,6 +26,7 @@ Metadata:
       - ParentZoneStack
       - ParentSSHBastionStack
       - ParentAlertStack
+      - ParentSecretStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -73,6 +74,10 @@ Parameters:
     Description: 'Optional identifier for the DB cluster snapshot from which you want to restore (leave blank to create an empty cluster).'
     Type: String
     Default: ''
+  ParentSecretStack:
+    Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
+    Type: String
+    Default: ''
   DBName:
     Description: 'Name of the database (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
     Type: String
@@ -88,7 +93,7 @@ Parameters:
     Type: 'String'
     Default: master
   DBMasterUserPassword:
-    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
+    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when ParentSecretStack is used).'
     Type: String
     NoEcho: true
     Default: ''
@@ -145,7 +150,15 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasNotDBSnapshotIdentifier: !Equals [!Ref DBSnapshotIdentifier, '']
   HasDBSnapshotIdentifier: !Not [!Condition HasNotDBSnapshotIdentifier]
+  HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
 Resources:
+  SecretTargetAttachment:
+    Condition: HasSecret
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      TargetId: !Ref DBCluster
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
+      TargetType: AWS::RDS::DBCluster
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'
@@ -205,7 +218,13 @@ Resources:
       EngineVersion: !Ref EngineVersion
       KmsKeyId: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}]
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
-      MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
+      MasterUserPassword: !If
+      - HasDBSnapshotIdentifier
+      - !Ref 'AWS::NoValue'
+      - !If
+        - HasSecret
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ":SecretString:password}}"]]}
+        - !Ref DBMasterUserPassword
       # PreferredBackupWindow: !Ref PreferredBackupWindow TODO re-enable as soon as CloudFormation bug ix fixed
       # PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow TODO re-enable as soon as CloudFormation bug ix fixed
       ScalingConfiguration:

--- a/state/rds-aurora-serverless.yaml
+++ b/state/rds-aurora-serverless.yaml
@@ -26,6 +26,7 @@ Metadata:
       - ParentZoneStack
       - ParentSSHBastionStack
       - ParentAlertStack
+      - ParentSecretStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -69,6 +70,10 @@ Parameters:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
     Type: String
     Default: ''
+  ParentSecretStack:
+    Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
+    Type: String
+    Default: ''
   DBSnapshotIdentifier:
     Description: 'Optional identifier for the DB cluster snapshot from which you want to restore (leave blank to create an empty cluster).'
     Type: String
@@ -88,7 +93,7 @@ Parameters:
     Type: 'String'
     Default: master
   DBMasterUserPassword:
-    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
+    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when ParentSecretStack is used).'
     Type: String
     NoEcho: true
     Default: ''
@@ -146,12 +151,20 @@ Mappings:
       EngineVersion: '5.7.mysql_aurora.2.07.1'
       Engine: 'aurora-mysql'
 Conditions:
+  HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasNotDBSnapshotIdentifier: !Equals [!Ref DBSnapshotIdentifier, '']
   HasDBSnapshotIdentifier: !Not [!Condition HasNotDBSnapshotIdentifier]
 Resources:
+  SecretTargetAttachment:
+    Condition: HasSecret
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      TargetId: !Ref DBCluster
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
+      TargetType: AWS::RDS::DBCluster
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'
@@ -218,7 +231,13 @@ Resources:
       EngineVersion: !FindInMap [EngineVersionMap, !Ref EngineVersion, EngineVersion]
       KmsKeyId: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}]
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
-      MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
+      MasterUserPassword: !If
+      - HasDBSnapshotIdentifier
+      - !Ref 'AWS::NoValue'
+      - !If
+        - HasSecret
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ":SecretString:password}}"]]}
+        - !Ref DBMasterUserPassword
       # PreferredBackupWindow: !Ref PreferredBackupWindow TODO re-enable as soon as CloudFormation bug ix fixed
       # PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow TODO re-enable as soon as CloudFormation bug ix fixed
       ScalingConfiguration:

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -36,6 +36,8 @@ Metadata:
       - DBBackupRetentionPeriod
       - DBMasterUsername
       - DBMasterUserPassword
+      - UseSecretsManager
+      - SecretName
       - SubDomainNameWithDot
       - ReadSubDomainNameWithDot
       - PreferredBackupWindow
@@ -102,9 +104,20 @@ Parameters:
     Type: 'String'
     Default: master
   DBMasterUserPassword:
-    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
+    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when UseSecretsManager is set to true).'
     Type: String
     NoEcho: true
+    Default: ''
+  UseSecretsManager:
+    Description: Set to true if you want to use Secrets Manager to handle the database credential handling
+    Type: String
+    Default: false
+    AllowedValues:
+    - true
+    - false
+  SecretName:
+    Description: Name of the Secret to use. Must be set if UseSecretsManager is set to true
+    Type: String
     Default: ''
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
@@ -198,7 +211,25 @@ Conditions:
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
   HasEngineMySQL: !Or [!Equals [!FindInMap [EngineMap, !Ref Engine, Engine], 'aurora'], !Equals [!FindInMap [EngineMap, !Ref Engine, Engine], 'aurora-mysql']]
+  HasSecretsManager: !Equals [!Ref UseSecretsManager, true]
 Resources:
+  Secret:
+    Condition: HasSecretsManager
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: !Ref SecretName
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DBMasterUsername}"}'
+        GenerateStringKey: "password"
+        PasswordLength: 30
+        ExcludeCharacters: '"@/\'
+  SecretTargetAttachment:
+    Condition: HasSecretsManager
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      SecretId: !Ref Secret
+      TargetId: !Ref DBCluster
+      TargetType: AWS::RDS::DBCluster
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'
@@ -279,7 +310,13 @@ Resources:
       EngineVersion: !FindInMap [EngineMap, !Ref Engine, EngineVersion]
       KmsKeyId: !If [HasKmsKeyAndNotDBSnapshotIdentifier, {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyId'}, !Ref 'AWS::NoValue']
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
-      MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
+      MasterUserPassword: !If
+      - HasDBSnapshotIdentifier
+      - !Ref 'AWS::NoValue'
+      - !If
+        - HasSecretsManager
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {"Ref": "Secret"}, ":SecretString:password}}"]]}
+        - !Ref DBMasterUserPassword
       Port: !FindInMap [EngineMap, !Ref Engine, Port]
       PreferredBackupWindow: !Ref PreferredBackupWindow
       PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -26,6 +26,7 @@ Metadata:
       - ParentZoneStack
       - ParentSSHBastionStack
       - ParentAlertStack
+      - ParentSecretStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -36,8 +37,6 @@ Metadata:
       - DBBackupRetentionPeriod
       - DBMasterUsername
       - DBMasterUserPassword
-      - UseSecretsManager
-      - SecretName
       - SubDomainNameWithDot
       - ReadSubDomainNameWithDot
       - PreferredBackupWindow
@@ -63,6 +62,10 @@ Parameters:
     Default: ''
   ParentAlertStack:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
+    Type: String
+    Default: ''
+  ParentSecretStack:
+    Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
     Type: String
     Default: ''
   Engine:
@@ -104,20 +107,9 @@ Parameters:
     Type: 'String'
     Default: master
   DBMasterUserPassword:
-    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when UseSecretsManager is set to true).'
+    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when ParentSecretStack is used).'
     Type: String
     NoEcho: true
-    Default: ''
-  UseSecretsManager:
-    Description: Set to true if you want to use Secrets Manager to handle the database credential handling
-    Type: String
-    Default: false
-    AllowedValues:
-    - true
-    - false
-  SecretName:
-    Description: Name of the Secret to use. Must be set if UseSecretsManager is set to true
-    Type: String
     Default: ''
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
@@ -204,6 +196,7 @@ Mappings:
       ClusterParameterGroupFamily: 'aurora-postgresql10'
       ParameterGroupFamily: 'aurora-postgresql10'
 Conditions:
+  HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
@@ -211,24 +204,13 @@ Conditions:
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
   HasEngineMySQL: !Or [!Equals [!FindInMap [EngineMap, !Ref Engine, Engine], 'aurora'], !Equals [!FindInMap [EngineMap, !Ref Engine, Engine], 'aurora-mysql']]
-  HasSecretsManager: !Equals [!Ref UseSecretsManager, true]
 Resources:
-  Secret:
-    Condition: HasSecretsManager
-    Type: 'AWS::SecretsManager::Secret'
-    Properties:
-      Name: !Ref SecretName
-      GenerateSecretString:
-        SecretStringTemplate: !Sub '{"username": "${DBMasterUsername}"}'
-        GenerateStringKey: "password"
-        PasswordLength: 30
-        ExcludeCharacters: '"@/\'
   SecretTargetAttachment:
-    Condition: HasSecretsManager
+    Condition: HasSecret
     Type: "AWS::SecretsManager::SecretTargetAttachment"
     Properties:
-      SecretId: !Ref Secret
       TargetId: !Ref DBCluster
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
       TargetType: AWS::RDS::DBCluster
   RecordSet:
     Condition: HasZone
@@ -314,8 +296,8 @@ Resources:
       - HasDBSnapshotIdentifier
       - !Ref 'AWS::NoValue'
       - !If
-        - HasSecretsManager
-        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {"Ref": "Secret"}, ":SecretString:password}}"]]}
+        - HasSecret
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ":SecretString:password}}"]]}
         - !Ref DBMasterUserPassword
       Port: !FindInMap [EngineMap, !Ref Engine, Port]
       PreferredBackupWindow: !Ref PreferredBackupWindow

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -27,6 +27,7 @@ Metadata:
       - ParentSSHBastionStack
       - ParentAlertStack
       - ParentSecretStack
+      - ParentSecretKmsKeyStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -66,6 +67,12 @@ Parameters:
     Default: ''
   ParentSecretStack:
     Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
+    Type: String
+    Default: ''
+  ParentSecretKmsKeyStack:
+    Description: >-
+      'Optional Stack name of parent KMS key stack based on security/kms-key.yaml template.
+      Set this if your secret uses a custom KMS key.'
     Type: String
     Default: ''
   Engine:
@@ -197,6 +204,7 @@ Mappings:
       ParameterGroupFamily: 'aurora-postgresql10'
 Conditions:
   HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
+  HasSecretKmsKey: !Not [!Equals [!Ref ParentSecretKmsKeyStack, '']]
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
@@ -212,6 +220,20 @@ Resources:
       TargetId: !Ref DBCluster
       SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
       TargetType: AWS::RDS::DBCluster
+  RotationSchedule:
+    Type: AWS::SecretsManager::RotationSchedule
+    DependsOn: SecretTargetAttachment
+    Properties:
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
+      RotationRules:
+        AutomaticallyAfterDays: 30
+      HostedRotationLambda:
+        RotationType: MySQLSingleUser
+        KmsKeyArn: !If [HasSecretKmsKey, {'Fn::ImportValue': !Sub '${ParentSecretKmsKeyStack}-KeyId'}, !Ref 'AWS:NoValue']
+        RotationLambdaName: # TODO
+        VpcSubnetIds: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-SubnetsPrivate'}]
+        VpcSecurityGroupIds:
+
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -27,7 +27,6 @@ Metadata:
       - ParentSSHBastionStack
       - ParentAlertStack
       - ParentSecretStack
-      - ParentSecretKmsKeyStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -67,12 +66,6 @@ Parameters:
     Default: ''
   ParentSecretStack:
     Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
-    Type: String
-    Default: ''
-  ParentSecretKmsKeyStack:
-    Description: >-
-      'Optional Stack name of parent KMS key stack based on security/kms-key.yaml template.
-      Set this if your secret uses a custom KMS key.'
     Type: String
     Default: ''
   Engine:
@@ -204,7 +197,6 @@ Mappings:
       ParameterGroupFamily: 'aurora-postgresql10'
 Conditions:
   HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
-  HasSecretKmsKey: !Not [!Equals [!Ref ParentSecretKmsKeyStack, '']]
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
@@ -220,20 +212,6 @@ Resources:
       TargetId: !Ref DBCluster
       SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
       TargetType: AWS::RDS::DBCluster
-  RotationSchedule:
-    Type: AWS::SecretsManager::RotationSchedule
-    DependsOn: SecretTargetAttachment
-    Properties:
-      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
-      RotationRules:
-        AutomaticallyAfterDays: 30
-      HostedRotationLambda:
-        RotationType: MySQLSingleUser
-        KmsKeyArn: !If [HasSecretKmsKey, {'Fn::ImportValue': !Sub '${ParentSecretKmsKeyStack}-KeyId'}, !Ref 'AWS:NoValue']
-        RotationLambdaName: # TODO
-        VpcSubnetIds: !Split [',', {'Fn::ImportValue': !Sub '${ParentVPCStack}-SubnetsPrivate'}]
-        VpcSecurityGroupIds:
-
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'

--- a/state/rds-mysql.yaml
+++ b/state/rds-mysql.yaml
@@ -26,6 +26,7 @@ Metadata:
       - ParentZoneStack
       - ParentSSHBastionStack
       - ParentAlertStack
+      - ParentSecretStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -67,6 +68,10 @@ Parameters:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
     Type: String
     Default: ''
+  ParentSecretStack:
+    Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
+    Type: String
+    Default: ''
   DBSnapshotIdentifier:
     Description: 'Optional name or Amazon Resource Name (ARN) of the DB snapshot from which you want to restore (leave blank to create an empty database).'
     Type: String
@@ -96,7 +101,7 @@ Parameters:
     Type: String
     Default: master
   DBMasterUserPassword:
-    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
+    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when ParentSecretStack is used).'
     Type: String
     NoEcho: true
     Default: ''
@@ -136,6 +141,7 @@ Parameters:
     AllowedValues: ['true', 'false']
     Default: 'false'
 Conditions:
+  HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
@@ -145,6 +151,13 @@ Conditions:
   HasDBParameterGroupName: !Not [!Equals [!Ref DBParameterGroupName, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
 Resources:
+  SecretTargetAttachment:
+    Condition: HasSecret
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      TargetId: !Ref DBInstance
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
+      TargetType: AWS::RDS::DBInstance
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'
@@ -202,7 +215,13 @@ Resources:
       EngineVersion: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref EngineVersion]
       KmsKeyId: !If [HasKmsKeyAndNotDBSnapshotIdentifier, {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyId'}, !Ref 'AWS::NoValue']
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
-      MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
+      MasterUserPassword: !If
+      - HasDBSnapshotIdentifier
+      - !Ref 'AWS::NoValue'
+      - !If
+        - HasSecret
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ":SecretString:password}}"]]}
+        - !Ref DBMasterUserPassword
       MultiAZ: !Ref DBMultiAZ
       OptionGroupName: !If [HasDBOptionGroupName, !Ref DBOptionGroupName, !Ref 'AWS::NoValue']
       PreferredBackupWindow: !Ref PreferredBackupWindow

--- a/state/rds-postgres.yaml
+++ b/state/rds-postgres.yaml
@@ -26,6 +26,7 @@ Metadata:
       - ParentZoneStack
       - ParentSSHBastionStack
       - ParentAlertStack
+      - ParentSecretStack
     - Label:
         default: 'RDS Parameters'
       Parameters:
@@ -67,6 +68,10 @@ Parameters:
     Description: 'Optional but recommended stack name of parent alert stack based on operations/alert.yaml template.'
     Type: String
     Default: ''
+  ParentSecretStack:
+    Description: 'Optional Stack name of parent SecretsManager Secret Stack based on state/secretsmanager-dbsecret.yaml template.'
+    Type: String
+    Default: ''
   DBSnapshotIdentifier:
     Description: 'Optional name or Amazon Resource Name (ARN) of the DB snapshot from which you want to restore (leave blank to create an empty database).'
     Type: String
@@ -96,7 +101,7 @@ Parameters:
     Type: String
     Default: master
   DBMasterUserPassword:
-    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot).'
+    Description: 'The master password for the DB instance (ignored when DBSnapshotIdentifier is set, value used from snapshot. Also ignored when ParentSecretStack is used).'
     Type: String
     NoEcho: true
     Default: ''
@@ -136,6 +141,7 @@ Parameters:
     AllowedValues: ['true', 'false']
     Default: 'false'
 Conditions:
+  HasSecret: !Not [!Equals [!Ref ParentSecretStack, '']]
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSSHBastionSecurityGroup: !Not [!Equals [!Ref ParentSSHBastionStack, '']]
@@ -145,6 +151,13 @@ Conditions:
   HasDBParameterGroupName: !Not [!Equals [!Ref DBParameterGroupName, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
 Resources:
+  SecretTargetAttachment:
+    Condition: HasSecret
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      TargetId: !Ref DBInstance
+      SecretId: {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}
+      TargetType: AWS::RDS::DBInstance
   RecordSet:
     Condition: HasZone
     Type: 'AWS::Route53::RecordSet'
@@ -202,7 +215,13 @@ Resources:
       EngineVersion: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref EngineVersion]
       KmsKeyId: !If [HasKmsKeyAndNotDBSnapshotIdentifier, {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyId'}, !Ref 'AWS::NoValue']
       MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
-      MasterUserPassword: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUserPassword]
+      MasterUserPassword: !If
+      - HasDBSnapshotIdentifier
+      - !Ref 'AWS::NoValue'
+      - !If
+        - HasSecret
+        - {"Fn::Join": ["", ["{{resolve:secretsmanager:", {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ":SecretString:password}}"]]}
+        - !Ref DBMasterUserPassword
       MultiAZ: !Ref DBMultiAZ
       OptionGroupName: !If [HasDBOptionGroupName, !Ref DBOptionGroupName, !Ref 'AWS::NoValue']
       PreferredBackupWindow: !Ref PreferredBackupWindow

--- a/state/secretsmanager-dbsecret.yaml
+++ b/state/secretsmanager-dbsecret.yaml
@@ -25,6 +25,7 @@ Metadata:
         default: 'Secret Settings'
       Parameters:
       - SecretName
+      - DeletionProtection
     - Label:
         default: 'DB Password Settings'
       Parameters:
@@ -62,7 +63,7 @@ Conditions:
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasSecretName: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasPassword: !Not [!Equals [!Ref DBPassword, '']]
-  HasDeletionProtection: !Equals [!Ref DeletionProtection, 'true']
+  HasDeletionProtection: !Equals [!Ref DeletionProtection, 'enabled']
 Resources:
   Secret:
     Type: 'AWS::SecretsManager::Secret'

--- a/state/secretsmanager-dbsecret.yaml
+++ b/state/secretsmanager-dbsecret.yaml
@@ -84,7 +84,6 @@ Resources:
         - !Sub '{"username":"${DBMasterUsername}","password":"${DBPassword}"}'
         - !Ref AWS::NoValue
   SecretResourcePolicy:
-<<<<<<< HEAD
     Condition: HasDeletionProtection
     Type: 'AWS::SecretsManager::ResourcePolicy'
     Properties:
@@ -97,20 +96,6 @@ Resources:
           Effect: Deny
           Principal:
             AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-=======
-      Condition: HasDeletionProtection
-      Type: 'AWS::SecretsManager::ResourcePolicy'
-      Properties:
-          SecretId: !Ref Secret
-          ResourcePolicy:
-            Version: 2012-10-17
-            Statement:
-            - Resource: '*'
-              Action: 'secretsmanager:DeleteSecret'
-              Effect: Deny
-              Principal:
-                AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
->>>>>>> a39255d (Remove rotation features. Add Deletion Protection for secret.)
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/state/secretsmanager-dbsecret.yaml
+++ b/state/secretsmanager-dbsecret.yaml
@@ -84,6 +84,7 @@ Resources:
         - !Sub '{"username":"${DBMasterUsername}","password":"${DBPassword}"}'
         - !Ref AWS::NoValue
   SecretResourcePolicy:
+<<<<<<< HEAD
     Condition: HasDeletionProtection
     Type: 'AWS::SecretsManager::ResourcePolicy'
     Properties:
@@ -96,6 +97,20 @@ Resources:
           Effect: Deny
           Principal:
             AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+=======
+      Condition: HasDeletionProtection
+      Type: 'AWS::SecretsManager::ResourcePolicy'
+      Properties:
+          SecretId: !Ref Secret
+          ResourcePolicy:
+            Version: 2012-10-17
+            Statement:
+            - Resource: '*'
+              Action: 'secretsmanager:DeleteSecret'
+              Effect: Deny
+              Principal:
+                AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+>>>>>>> a39255d (Remove rotation features. Add Deletion Protection for secret.)
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/state/secretsmanager-dbsecret.yaml
+++ b/state/secretsmanager-dbsecret.yaml
@@ -51,10 +51,18 @@ Parameters:
       Use this if you need to preset the password or when you want to duplicate'
     Type: 'String'
     Default: ''
+  DeletionProtection:
+    Description: Prevent Deletion via Resource Policy
+    Type: 'String'
+    Default: 'disabled'
+    AllowedValues:
+    - 'enabled'
+    - 'disabled'
 Conditions:
   HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasSecretName: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
   HasPassword: !Not [!Equals [!Ref DBPassword, '']]
+  HasDeletionProtection: !Equals [!Ref DeletionProtection, 'true']
 Resources:
   Secret:
     Type: 'AWS::SecretsManager::Secret'
@@ -75,7 +83,19 @@ Resources:
         - HasPassword
         - !Sub '{"username":"${DBMasterUsername}","password":"${DBPassword}"}'
         - !Ref AWS::NoValue
-
+  SecretResourcePolicy:
+    Condition: HasDeletionProtection
+    Type: 'AWS::SecretsManager::ResourcePolicy'
+    Properties:
+      SecretId: !Ref Secret
+      ResourcePolicy:
+        Version: 2012-10-17
+        Statement:
+        - Resource: '*'
+          Action: 'secretsmanager:DeleteSecret'
+          Effect: Deny
+          Principal:
+            AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
 Outputs:
   TemplateID:
     Description: 'cloudonaut.io template id.'

--- a/state/secretsmanager-dbsecret.yaml
+++ b/state/secretsmanager-dbsecret.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'State: RDS MySQL, a cloudonaut.io template, sponsored by https://github.com/ngault'
+Description: 'State: Database Secret, a cloudonaut.io template, sponsored by https://github.com/ngault'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -30,7 +30,6 @@ Metadata:
       Parameters:
       - DBMasterUsername
       - DBPassword
-
 Parameters:
   ParentKmsKeyStack:
     Description: >-
@@ -76,7 +75,6 @@ Resources:
         - HasPassword
         - !Sub '{"username":"${DBMasterUsername}","password":"${DBPassword}"}'
         - !Ref AWS::NoValue
-
 
 Outputs:
   TemplateID:

--- a/state/secretsmanager-dbsecret.yaml
+++ b/state/secretsmanager-dbsecret.yaml
@@ -1,0 +1,95 @@
+---
+# Copyright 2018 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'State: RDS MySQL, a cloudonaut.io template, sponsored by https://github.com/ngault'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentKmsKeyStack
+    - Label:
+        default: 'Secret Settings'
+      Parameters:
+      - SecretName
+    - Label:
+        default: 'DB Password Settings'
+      Parameters:
+      - DBMasterUsername
+      - DBPassword
+
+Parameters:
+  ParentKmsKeyStack:
+    Description: >-
+      'Optional Stack name of parent KMS key stack based on security/kms-key.yaml template
+      (If you do not specify this value, then Secrets Manager defaults to the AWS account CMK, aws/secretsmanager).'
+    Type: String
+    Default: ''
+  SecretName:
+    Description: Name of the Secret.
+    Type: String
+    Default: ''
+  DBMasterUsername:
+    Description: 'The master user name for a DB instance.'
+    Type: 'String'
+    Default: master
+  DBPassword:
+    Description: >-
+      'Set the password to be used in the secret.
+      Use this if you need to preset the password or when you want to duplicate'
+    Type: 'String'
+    Default: ''
+Conditions:
+  HasKmsKey: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
+  HasSecretName: !Not [!Equals [!Ref ParentKmsKeyStack, '']]
+  HasPassword: !Not [!Equals [!Ref DBPassword, '']]
+Resources:
+  Secret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: !If [HasSecretName, !Ref SecretName, !Ref 'AWS::StackName']
+      KmsKeyId: !If [HasKmsKey, {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyId'}, !Ref 'AWS::NoValue']
+      GenerateSecretString:
+        !If
+        - HasPassword
+        - !Ref AWS::NoValue
+        -
+          SecretStringTemplate: !Sub '{"username": "${DBMasterUsername}"}'
+          GenerateStringKey: "password"
+          PasswordLength: 30
+          ExcludeCharacters: '"@/\'
+      SecretString:
+        !If
+        - HasPassword
+        - !Sub '{"username":"${DBMasterUsername}","password":"${DBPassword}"}'
+        - !Ref AWS::NoValue
+
+
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'state/secretsmanager-secret.yaml'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+  SecretArn:
+    Description: 'Secret Arn'
+    Value: !Ref Secret
+    Export:
+      Name: !Sub '${AWS::StackName}-SecretArn'


### PR DESCRIPTION
---
I added support for using Secrets manager with the RDS Aurora Template and thought it might be useful for other users of your templates as well.
This makes it possible to create a database without having to provide the password as a parameter but automatically generates a password and stores it in a Secrets Manager Secret.
When building databases I never have to access the password directly. But if someone just wants to copy and paste the password in their configuration they can still do so by retrieving it from Secrets Manager.
This should be completely backwards compatible.
All linting and validation came back without errors.
I only did this for one of the templates for now to start the discussion. But I would be willing to add to this Pull Request if you think this would be useful.
