### PR TITLE
[Improvement] security/auth-proxy-ha-github-orga - Add SkipAuthRegex parameter

### DIFF
--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -34,6 +34,7 @@ Metadata:
       - CertificateArn
       - Upstream
       - CookieSecret
+      - SkipAuthRegex
     - Label:
         default: 'EC2 Parameters'
       Parameters:
@@ -123,6 +124,10 @@ Parameters:
     Description: 'Seed string for secure cookies. Create one with python -c ''import os,base64; print base64.b64encode(os.urandom(16))'''
     Type: String
     NoEcho: true
+  SkipAuthRegex:
+    Description: 'Regex for path(s) which will be passed through the proxy without requiring Github authentication. The default is to require authentication for all paths.'
+    Type: String
+    Default: ''
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
@@ -190,6 +195,7 @@ Conditions:
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
+  HasSkipAuthRegex: !Not [!Equals [!Ref SkipAuthRegex, '']]
 Resources:
   Logs:
     Type: 'AWS::Logs::LogGroup'
@@ -675,23 +681,26 @@ Resources:
             '/opt/oauth2-proxy': 'https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v6.1.1/oauth2-proxy-v6.1.1.linux-amd64.tar.gz'
           files:
             '/etc/oauth2-proxy.cfg':
-              content: !Sub |
-                ## OAuth2 Proxy Config File
-                ## https://github.com/oauth2-proxy/oauth2-proxy
-                http_address = "0.0.0.0:4180"
-                upstreams = [
-                  "${Upstream}"
-                ]
-                request_logging = false
-                pass_basic_auth = false
-                email_domains = [
-                  "*"
-                ]
-                client_id = "${GitHubClientId}"
-                client_secret = "${GitHubClientSecret}"
-                cookie_secret = "${CookieSecret}"
-                provider = "github"
-                github_org = "${GitHubOrganization}"
+              content: !Sub
+              - |
+                  ## OAuth2 Proxy Config File
+                  ## https://github.com/oauth2-proxy/oauth2-proxy
+                  http_address = "0.0.0.0:4180"
+                  upstreams = [
+                    "${Upstream}"
+                  ]
+                  ${SkipAuthRegexBlock}
+                  request_logging = false
+                  pass_basic_auth = false
+                  email_domains = [
+                    "*"
+                  ]
+                  client_id = "${GitHubClientId}"
+                  client_secret = "${GitHubClientSecret}"
+                  cookie_secret = "${CookieSecret}"
+                  provider = "github"
+                  github_org = "${GitHubOrganization}"
+              - {SkipAuthRegexBlock: !If [HasSkipAuthRegex, !Join ['', ['skip_auth_regex = ["', !Ref SkipAuthRegex, '"]']], '']}
               mode: '000644'
               owner: root
               group: root


### PR DESCRIPTION
…-orga.yaml

---

This exposes the `skip_auth_regex` option of the `oauth2-proxy.cfg` file as a CloudFormation parameter.

https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options
> bypass authentication for requests paths that match (may be given multiple times)

This should be suitably generic, but is to support a use case where I am running a Jenkins behind an auth proxy, but I want to selectively allow Github to post webhooks directly to Jenkins to notify of changes, and to trigger builds without having to rely on Jenkins polling when behind an auth proxy.

```yaml
    Parameters:
      SkipAuthRegex: '^\/github-webhook\/$'
```
