### PR TITLE
[Improvement] state/s3 - Enabling S3 Bucket Keys

### DIFF
--- a/operations/terraform-state.yaml
+++ b/operations/terraform-state.yaml
@@ -49,7 +49,8 @@ Resources:
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
-        - ServerSideEncryptionByDefault:
+        - BucketKeyEnabled: true
+          ServerSideEncryptionByDefault:
             KMSMasterKeyID: {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}
             SSEAlgorithm: 'aws:kms'
       BucketName: !Ref TerraformStateIdentifier

--- a/state/s3.yaml
+++ b/state/s3.yaml
@@ -151,7 +151,7 @@ Resources:
         QueueConfigurations:
         - !If [HasS3VirusScan, {Event: 's3:ObjectCreated:*', Queue: {'Fn::ImportValue': !Sub '${ParentS3VirusScanStack}-ScanQueueArn'}}, !Ref 'AWS::NoValue']
       VersioningConfiguration: !If [HasVersioning, {Status: Enabled}, !If [HadVersioning, {Status: Suspended}, !Ref 'AWS::NoValue']]
-      BucketEncryption: !If [HasKmsKey, {ServerSideEncryptionConfiguration: [{ServerSideEncryptionByDefault: {KMSMasterKeyID: {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}, SSEAlgorithm: 'aws:kms'}}]}, !Ref 'AWS::NoValue']
+      BucketEncryption: !If [HasKmsKey, {ServerSideEncryptionConfiguration: [{BucketKeyEnabled: true, ServerSideEncryptionByDefault: {KMSMasterKeyID: {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}, SSEAlgorithm: 'aws:kms'}}]}, !Ref 'AWS::NoValue']
   BucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
     Properties:


### PR DESCRIPTION
Enabling Bucket Keys to [reduce the cost of SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html).
