### PR TITLE
[Security] security/auth-proxy-ha-github-orga - Update OAuth2 Proxy to 7.1.0

### DIFF
--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -678,7 +678,7 @@ Resources:
           users:
             oauth2-proxy: {}
           sources:
-            '/opt/oauth2-proxy': 'https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v7.0.1/oauth2-proxy-v7.0.1.linux-amd64.tar.gz'
+            '/opt/oauth2-proxy': 'https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v7.1.0/oauth2-proxy-v7.1.0.linux-amd64.tar.gz'
           files:
             '/etc/oauth2-proxy.cfg':
               content: !Sub
@@ -719,7 +719,7 @@ Resources:
                 User=oauth2-proxy
                 Group=oauth2-proxy
 
-                ExecStart=/opt/oauth2-proxy/oauth2-proxy-v7.0.1.linux-amd64/oauth2-proxy --config=/etc/oauth2-proxy.cfg
+                ExecStart=/opt/oauth2-proxy/oauth2-proxy-v7.1.0.linux-amd64/oauth2-proxy --config=/etc/oauth2-proxy.cfg
                 ExecReload=/bin/kill -HUP $MAINPID
 
                 KillMode=process


### PR DESCRIPTION
https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.1.0