### PR TITLE
Add circuit breaker options to ECS Services

### DIFF
--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -44,7 +44,6 @@ Metadata:
       - MaxCapacity
       - MinCapacity
       - HealthCheckGracePeriod
-      - CircuitBreaker
     - Label:
         default: 'Permission Parameters'
       Parameters:
@@ -134,17 +133,11 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
-  CircuitBreaker:
-    Description: 'Enable circuit breaker for Service deployments'
-    Type: String
-    Default: 'true'
-    AllowedValues: ['true', 'false']
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
   HasLoadBalancerPath: !Not [!Equals [!Ref LoadBalancerPath, '']]
   HasLoadBalancerHostPattern: !Not [!Equals [!Ref LoadBalancerHostPattern, '']]
-  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
@@ -327,8 +320,8 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
-          Enable: !If [HasCircuitBreaker, true, false]
-          Rollback: !If [HasCircuitBreaker, true, false]
+          Enable: true
+          Rollback: true
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -44,6 +44,7 @@ Metadata:
       - MaxCapacity
       - MinCapacity
       - HealthCheckGracePeriod
+      - CircuitBreaker
     - Label:
         default: 'Permission Parameters'
       Parameters:
@@ -133,11 +134,17 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
+  CircuitBreaker:
+    Description: 'Enable circuit breaker for Service deployments'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
   HasLoadBalancerPath: !Not [!Equals [!Ref LoadBalancerPath, '']]
   HasLoadBalancerHostPattern: !Not [!Equals [!Ref LoadBalancerHostPattern, '']]
+  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
@@ -319,6 +326,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: !If [HasCircuitBreaker, true, false]
+          Rollback: !If [HasCircuitBreaker, true, false]
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -47,7 +47,6 @@ Metadata:
       - MaxCapacity
       - MinCapacity
       - HealthCheckGracePeriod
-      - CircuitBreaker
     - Label:
         default: 'Permission Parameters'
       Parameters:
@@ -143,11 +142,6 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
-  CircuitBreaker:
-    Description: 'Enable circuit breaker for Service deployments'
-    Type: String
-    Default: 'true'
-    AllowedValues: ['true', 'false']
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
@@ -157,7 +151,6 @@ Conditions:
   HasLoadBalancerCertificateArn: !Not [!Equals [!Ref LoadBalancerCertificateArn, '']]
   HasAuthProxySecurityGroupAndLoadBalancerCertificateArn: !And [!Condition HasAuthProxySecurityGroup, !Condition HasLoadBalancerCertificateArn]
   HasNotAuthProxySecurityGroupAndLoadBalancerCertificateArn: !And [!Condition HasNotAuthProxySecurityGroup, !Condition HasLoadBalancerCertificateArn]
-  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasZoneAndLoadBalancerSchemeInternetFacing: !And [!Condition HasZone, !Condition HasLoadBalancerSchemeInternetFacing]
@@ -436,8 +429,8 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
         DeploymentCircuitBreaker:
-          Enable: !If [HasCircuitBreaker, true, false]
-          Rollback: !If [HasCircuitBreaker, true, false]
+          Enable: true
+          Rollback: true
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -47,6 +47,7 @@ Metadata:
       - MaxCapacity
       - MinCapacity
       - HealthCheckGracePeriod
+      - CircuitBreaker
     - Label:
         default: 'Permission Parameters'
       Parameters:
@@ -142,6 +143,11 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
+  CircuitBreaker:
+    Description: 'Enable circuit breaker for Service deployments'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
@@ -151,6 +157,7 @@ Conditions:
   HasLoadBalancerCertificateArn: !Not [!Equals [!Ref LoadBalancerCertificateArn, '']]
   HasAuthProxySecurityGroupAndLoadBalancerCertificateArn: !And [!Condition HasAuthProxySecurityGroup, !Condition HasLoadBalancerCertificateArn]
   HasNotAuthProxySecurityGroupAndLoadBalancerCertificateArn: !And [!Condition HasNotAuthProxySecurityGroup, !Condition HasLoadBalancerCertificateArn]
+  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasZoneAndLoadBalancerSchemeInternetFacing: !And [!Condition HasZone, !Condition HasLoadBalancerSchemeInternetFacing]
@@ -428,6 +435,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
+        DeploymentCircuitBreaker:
+          Enable: !If [HasCircuitBreaker, true, false]
+          Rollback: !If [HasCircuitBreaker, true, false]
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -68,6 +68,7 @@ Metadata:
       - Memory
       - SubnetsReach
       - AutoScaling
+      - CircuitBreaker
       - Spot
       - DesiredCount
       - MaxCapacity
@@ -285,6 +286,11 @@ Parameters:
     Type: String
     Default: false
     AllowedValues: [true, false]
+  CircuitBreaker:
+    Description: 'Enable circuit breaker for Service deployments'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
 Mappings:
   CpuMap:
     '0.25':
@@ -365,6 +371,7 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
+  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
@@ -541,6 +548,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
+        DeploymentCircuitBreaker:
+          Enable: !If [HasCircuitBreaker, true, false]
+          Rollback: !If [HasCircuitBreaker, true, false]
       DesiredCount: !Ref DesiredCount
       ServiceRegistries:
       - ContainerName: !If [HasProxyImage, proxy, app]

--- a/fargate/service-cloudmap.yaml
+++ b/fargate/service-cloudmap.yaml
@@ -68,7 +68,6 @@ Metadata:
       - Memory
       - SubnetsReach
       - AutoScaling
-      - CircuitBreaker
       - Spot
       - DesiredCount
       - MaxCapacity
@@ -286,11 +285,6 @@ Parameters:
     Type: String
     Default: false
     AllowedValues: [true, false]
-  CircuitBreaker:
-    Description: 'Enable circuit breaker for Service deployments'
-    Type: String
-    Default: 'true'
-    AllowedValues: ['true', 'false']
 Mappings:
   CpuMap:
     '0.25':
@@ -371,7 +365,6 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
-  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
@@ -549,8 +542,8 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
         DeploymentCircuitBreaker:
-          Enable: !If [HasCircuitBreaker, true, false]
-          Rollback: !If [HasCircuitBreaker, true, false]
+          Enable: true
+          Rollback: true
       DesiredCount: !Ref DesiredCount
       ServiceRegistries:
       - ContainerName: !If [HasProxyImage, proxy, app]

--- a/fargate/service-cluster-alb.yaml
+++ b/fargate/service-cluster-alb.yaml
@@ -74,6 +74,7 @@ Metadata:
       - Memory
       - SubnetsReach
       - AutoScaling
+      - CircuitBreaker
       - Spot
       - DesiredCount
       - MaxCapacity
@@ -326,6 +327,11 @@ Parameters:
     Type: String
     Default: false
     AllowedValues: [true, false]
+  CircuitBreaker:
+    Description: 'Enable circuit breaker for Service deployments'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
 Mappings:
   CpuMap:
     '0.25':
@@ -410,6 +416,7 @@ Conditions:
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
+  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
@@ -672,6 +679,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
+        DeploymentCircuitBreaker:
+          Enable: !If [HasCircuitBreaker, true, false]
+          Rollback: !If [HasCircuitBreaker, true, false]
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/fargate/service-cluster-alb.yaml
+++ b/fargate/service-cluster-alb.yaml
@@ -74,7 +74,6 @@ Metadata:
       - Memory
       - SubnetsReach
       - AutoScaling
-      - CircuitBreaker
       - Spot
       - DesiredCount
       - MaxCapacity
@@ -327,11 +326,6 @@ Parameters:
     Type: String
     Default: false
     AllowedValues: [true, false]
-  CircuitBreaker:
-    Description: 'Enable circuit breaker for Service deployments'
-    Type: String
-    Default: 'true'
-    AllowedValues: ['true', 'false']
 Mappings:
   CpuMap:
     '0.25':
@@ -416,7 +410,6 @@ Conditions:
   HasZone: !Not [!Equals [!Ref ParentZoneStack, '']]
   HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
-  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
@@ -680,8 +673,8 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
         DeploymentCircuitBreaker:
-          Enable: !If [HasCircuitBreaker, true, false]
-          Rollback: !If [HasCircuitBreaker, true, false]
+          Enable: true
+          Rollback: true
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/fargate/service-dedicated-alb.yaml
+++ b/fargate/service-dedicated-alb.yaml
@@ -76,6 +76,7 @@ Metadata:
       - Memory
       - SubnetsReach
       - AutoScaling
+      - CircuitBreaker
       - Spot
       - DesiredCount
       - MaxCapacity
@@ -331,6 +332,11 @@ Parameters:
     Type: String
     Default: false
     AllowedValues: [true, false]
+  CircuitBreaker:
+    Description: 'Enable circuit breaker for Service deployments'
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
 Mappings:
   CpuMap:
     '0.25':
@@ -421,6 +427,7 @@ Conditions:
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
   HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
+  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
@@ -808,6 +815,9 @@ Resources:
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
+        DeploymentCircuitBreaker:
+          Enable: !If [HasCircuitBreaker, true, false]
+          Rollback: !If [HasCircuitBreaker, true, false]
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:

--- a/fargate/service-dedicated-alb.yaml
+++ b/fargate/service-dedicated-alb.yaml
@@ -76,7 +76,6 @@ Metadata:
       - Memory
       - SubnetsReach
       - AutoScaling
-      - CircuitBreaker
       - Spot
       - DesiredCount
       - MaxCapacity
@@ -332,11 +331,6 @@ Parameters:
     Type: String
     Default: false
     AllowedValues: [true, false]
-  CircuitBreaker:
-    Description: 'Enable circuit breaker for Service deployments'
-    Type: String
-    Default: 'true'
-    AllowedValues: ['true', 'false']
 Mappings:
   CpuMap:
     '0.25':
@@ -427,7 +421,6 @@ Conditions:
   HasS3Bucket: !Not [!Equals [!Ref ParentS3StackAccessLog, '']]
   HasSubnetsReachPublic: !Equals [!Ref SubnetsReach, Public]
   HasAutoScaling: !Equals [!Ref AutoScaling, 'true']
-  HasCircuitBreaker: !Equals [!Ref CircuitBreaker, 'true']
   HasClientSecurityGroup1: !Not [!Equals [!Ref ParentClientStack1, '']]
   HasClientSecurityGroup2: !Not [!Equals [!Ref ParentClientStack2, '']]
   HasClientSecurityGroup3: !Not [!Equals [!Ref ParentClientStack3, '']]
@@ -816,8 +809,8 @@ Resources:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
         DeploymentCircuitBreaker:
-          Enable: !If [HasCircuitBreaker, true, false]
-          Rollback: !If [HasCircuitBreaker, true, false]
+          Enable: true
+          Rollback: true
       DesiredCount: !Ref DesiredCount
       HealthCheckGracePeriodSeconds: !Ref HealthCheckGracePeriod
       LoadBalancers:


### PR DESCRIPTION
---

I added ecs circuit breakers. this is extremely helpful when a deployment fails because you do not have to wait "forever" until cloud formation notices the deployment isn't working.
