### PR TITLE
[Improvement] wordpress/* - Upgrade PHP to 7.4

### DIFF
--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -895,8 +895,8 @@ Resources:
         extras:
           commands:
             'a_enable_php':
-              command: 'amazon-linux-extras enable php7.2 && yum -y clean metadata'
-              test: "! grep -Fxq '[amzn2extra-php7.2]' /etc/yum.repos.d/amzn2-extras.repo"
+              command: 'amazon-linux-extras enable php7.4 && yum -y clean metadata'
+              test: "! grep -Fxq '[amzn2extra-php7.4]' /etc/yum.repos.d/amzn2-extras.repo"
         config:
           packages:
             yum:

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -1027,8 +1027,8 @@ Resources:
         extras:
           commands:
             'a_enable_php':
-              command: 'amazon-linux-extras enable php7.2 && yum -y clean metadata'
-              test: "! grep -Fxq '[amzn2extra-php7.2]' /etc/yum.repos.d/amzn2-extras.repo"
+              command: 'amazon-linux-extras enable php7.4 && yum -y clean metadata'
+              test: "! grep -Fxq '[amzn2extra-php7.4]' /etc/yum.repos.d/amzn2-extras.repo"
         config:
           packages:
             yum:


### PR DESCRIPTION
PHP 7.2 has been EOL for quite some time so I took the liberty to upgrade it to 7.4 within the WordPress templates.

[https://www.php.net/supported-versions.php](https://www.php.net/supported-versions.php)