### PR TITLE
[Bug Fix] state/elasticache-redis - ConfigurationEndPoint if HasClusterModeEnabled instead PrimaryAdress

### DIFF
--- a/state/elasticache-redis.yaml
+++ b/state/elasticache-redis.yaml
@@ -197,7 +197,7 @@ Resources:
         HostedZoneName:
           'Fn::ImportValue': !Sub '${ParentZoneStack}-HostedZoneName'
       ResourceRecords:
-      - !GetAtt 'ReplicationGroup.PrimaryEndPoint.Address'
+      - !If [HasClusterModeEnabled, !GetAtt 'ReplicationGroup.ConfigurationEndPoint.Address', !GetAtt 'ReplicationGroup.PrimaryEndPoint.Address']
       TTL: 60
       Type: CNAME
   CacheParameterGroup:


### PR DESCRIPTION
When creating the Cluster with more than one Shard the creation fails.
I think this is due to using ReplicationGroup.PrimaryAdress instead of ReplicationGroup.ConfigurationEndPoint for the RecordSet Resource when cluster-mode is on.

ErrorMessage:
```
RecordSet | CREATE_FAILED | Template error: Primary endpoint was not found for replication group abc-test123
```
