### PR TITLE
[Security] * - Update Amazon Linux 2 to 20211001.1

### DIFF
--- a/ec2/README.md
+++ b/ec2/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/ec2/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20210813.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211001.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/ecs/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-ecs-hvm-2.0.20210902-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  ECSAMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-ecs-hvm-2.0.20210929-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  ECSAMI: '$ami'\n"; done
 ```

--- a/ecs/cluster-cost-optimized.yaml
+++ b/ecs/cluster-cost-optimized.yaml
@@ -175,47 +175,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      ECSAMI: 'ami-0c92e3d4b0e90eeef'
+      ECSAMI: 'ami-01ac4eeba86f9a8d5'
     'eu-north-1':
-      ECSAMI: 'ami-0e3d6469fb7b7bf3d'
+      ECSAMI: 'ami-02ed85945b0e46f6f'
     'ap-south-1':
-      ECSAMI: 'ami-0b8087b9a726c87de'
+      ECSAMI: 'ami-0405ea06ab2621cff'
     'eu-west-3':
-      ECSAMI: 'ami-00f9a9c1fc2208dc6'
+      ECSAMI: 'ami-004138ffbf7aad984'
     'eu-west-2':
-      ECSAMI: 'ami-0687841b15858229f'
+      ECSAMI: 'ami-0b5e334d61108a1aa'
     'eu-south-1':
-      ECSAMI: 'ami-09a906e9202ec2903'
+      ECSAMI: 'ami-00d7a4084bac16c81'
     'eu-west-1':
-      ECSAMI: 'ami-037d203e54a0a9c14'
+      ECSAMI: 'ami-0fdb1527ad8bf80f7'
     'ap-northeast-3':
-      ECSAMI: 'ami-0442df3888d708161'
+      ECSAMI: 'ami-025db54f56fda879d'
     'ap-northeast-2':
-      ECSAMI: 'ami-0a9925891cc681519'
+      ECSAMI: 'ami-0cacf8fb201c07e6b'
     'me-south-1':
-      ECSAMI: 'ami-0f52e412d0c294974'
+      ECSAMI: 'ami-05f7a182e037b82af'
     'ap-northeast-1':
-      ECSAMI: 'ami-0822fa1ed6836019b'
+      ECSAMI: 'ami-0b155218d6916661a'
     'sa-east-1':
-      ECSAMI: 'ami-0538c9b9c31d85978'
+      ECSAMI: 'ami-00f653b3399483762'
     'ca-central-1':
-      ECSAMI: 'ami-01a77b0247d81c003'
+      ECSAMI: 'ami-0a5cfc26b04c4a20e'
     'ap-east-1':
-      ECSAMI: 'ami-04ea8426c3bd7441f'
+      ECSAMI: 'ami-09bab3582fd4f92a9'
     'ap-southeast-1':
-      ECSAMI: 'ami-03615fd9ef545c196'
+      ECSAMI: 'ami-0f9e7ad4abf49df6b'
     'ap-southeast-2':
-      ECSAMI: 'ami-0310d0e01c1e033c0'
+      ECSAMI: 'ami-0cdf16bb10adcaaa1'
     'eu-central-1':
-      ECSAMI: 'ami-06e3e9f1bf6945099'
+      ECSAMI: 'ami-0da383d2d6bdb9100'
     'us-east-1':
-      ECSAMI: 'ami-03fe4d5b1d229063a'
+      ECSAMI: 'ami-04942e54b391af5d0'
     'us-east-2':
-      ECSAMI: 'ami-07f26587d2d1c39a7'
+      ECSAMI: 'ami-0c38a2329ed4dae9a'
     'us-west-1':
-      ECSAMI: 'ami-0c6712b4108e5909b'
+      ECSAMI: 'ami-0ab1b97c4bbf16bf3'
     'us-west-2':
-      ECSAMI: 'ami-09f253e2f2e610302'
+      ECSAMI: 'ami-06c73a8827b372409'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -207,47 +207,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      ECSAMI: 'ami-0c92e3d4b0e90eeef'
+      ECSAMI: 'ami-01ac4eeba86f9a8d5'
     'eu-north-1':
-      ECSAMI: 'ami-0e3d6469fb7b7bf3d'
+      ECSAMI: 'ami-02ed85945b0e46f6f'
     'ap-south-1':
-      ECSAMI: 'ami-0b8087b9a726c87de'
+      ECSAMI: 'ami-0405ea06ab2621cff'
     'eu-west-3':
-      ECSAMI: 'ami-00f9a9c1fc2208dc6'
+      ECSAMI: 'ami-004138ffbf7aad984'
     'eu-west-2':
-      ECSAMI: 'ami-0687841b15858229f'
+      ECSAMI: 'ami-0b5e334d61108a1aa'
     'eu-south-1':
-      ECSAMI: 'ami-09a906e9202ec2903'
+      ECSAMI: 'ami-00d7a4084bac16c81'
     'eu-west-1':
-      ECSAMI: 'ami-037d203e54a0a9c14'
+      ECSAMI: 'ami-0fdb1527ad8bf80f7'
     'ap-northeast-3':
-      ECSAMI: 'ami-0442df3888d708161'
+      ECSAMI: 'ami-025db54f56fda879d'
     'ap-northeast-2':
-      ECSAMI: 'ami-0a9925891cc681519'
+      ECSAMI: 'ami-0cacf8fb201c07e6b'
     'me-south-1':
-      ECSAMI: 'ami-0f52e412d0c294974'
+      ECSAMI: 'ami-05f7a182e037b82af'
     'ap-northeast-1':
-      ECSAMI: 'ami-0822fa1ed6836019b'
+      ECSAMI: 'ami-0b155218d6916661a'
     'sa-east-1':
-      ECSAMI: 'ami-0538c9b9c31d85978'
+      ECSAMI: 'ami-00f653b3399483762'
     'ca-central-1':
-      ECSAMI: 'ami-01a77b0247d81c003'
+      ECSAMI: 'ami-0a5cfc26b04c4a20e'
     'ap-east-1':
-      ECSAMI: 'ami-04ea8426c3bd7441f'
+      ECSAMI: 'ami-09bab3582fd4f92a9'
     'ap-southeast-1':
-      ECSAMI: 'ami-03615fd9ef545c196'
+      ECSAMI: 'ami-0f9e7ad4abf49df6b'
     'ap-southeast-2':
-      ECSAMI: 'ami-0310d0e01c1e033c0'
+      ECSAMI: 'ami-0cdf16bb10adcaaa1'
     'eu-central-1':
-      ECSAMI: 'ami-06e3e9f1bf6945099'
+      ECSAMI: 'ami-0da383d2d6bdb9100'
     'us-east-1':
-      ECSAMI: 'ami-03fe4d5b1d229063a'
+      ECSAMI: 'ami-04942e54b391af5d0'
     'us-east-2':
-      ECSAMI: 'ami-07f26587d2d1c39a7'
+      ECSAMI: 'ami-0c38a2329ed4dae9a'
     'us-west-1':
-      ECSAMI: 'ami-0c6712b4108e5909b'
+      ECSAMI: 'ami-0ab1b97c4bbf16bf3'
     'us-west-2':
-      ECSAMI: 'ami-09f253e2f2e610302'
+      ECSAMI: 'ami-06c73a8827b372409'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/jenkins/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20210813.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211001.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -219,47 +219,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasZeroAgents: !Equals [!Ref AgentMinSize, '0']

--- a/jenkins/jenkins2-ha.yaml
+++ b/jenkins/jenkins2-ha.yaml
@@ -167,47 +167,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/security/README.md
+++ b/security/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/security/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20210813.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211001.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -145,47 +145,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -9,10 +9,10 @@ To update the region map execute the following lines in your terminal:
 
 #### AMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20210813.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211001.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 #### NATAMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn-ami-vpc-nat-2018.03.0.20210721.0-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  NATAMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn-ami-vpc-nat-2018.03.0.20211001.0-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  NATAMI: '$ami'\n"; done
 ```

--- a/vpc/vpc-nat-instance.yaml
+++ b/vpc/vpc-nat-instance.yaml
@@ -99,47 +99,47 @@ Parameters:
 Mappings:
   RegionMap: # TODO update to Amazon Linux 2 (don't forget to adjust awslogs config as well)
     'af-south-1':
-      NATAMI: 'ami-02a4d53bdd3e50b64'
+      NATAMI: 'ami-0301591cb09254660'
     'eu-north-1':
-      NATAMI: 'ami-0b162e954f43a67ad'
+      NATAMI: 'ami-0213f0a5b0267a261'
     'ap-south-1':
-      NATAMI: 'ami-0b8a83c274c0fd9d2'
+      NATAMI: 'ami-0a58809eee80aa0aa'
     'eu-west-3':
-      NATAMI: 'ami-02f832028d044c162'
+      NATAMI: 'ami-052a40b25c41dd3e1'
     'eu-west-2':
-      NATAMI: 'ami-0a296f7689b0f7b35'
+      NATAMI: 'ami-00400a198e1509988'
     'eu-south-1':
-      NATAMI: 'ami-0d498f2f5b0f87b4a'
+      NATAMI: 'ami-05aeb6196027c6d79'
     'eu-west-1':
-      NATAMI: 'ami-09e45ffc9fee3dce1'
+      NATAMI: 'ami-044677ea00df5825f'
     'ap-northeast-3':
-      NATAMI: 'ami-0b7496b4128543db2'
+      NATAMI: 'ami-0d182d3da86926c86'
     'ap-northeast-2':
-      NATAMI: 'ami-0e046f0c741e508db'
+      NATAMI: 'ami-0521b2a62a9329809'
     'me-south-1':
-      NATAMI: 'ami-0f191ff1591ba2030'
+      NATAMI: 'ami-024a7e72d23b4a447'
     'ap-northeast-1':
-      NATAMI: 'ami-055e1ec80e281a291'
+      NATAMI: 'ami-076209132bc69adb0'
     'sa-east-1':
-      NATAMI: 'ami-02dacf3ff2c30e620'
+      NATAMI: 'ami-06909414df2a438ae'
     'ca-central-1':
-      NATAMI: 'ami-0cf2edb7c4010a034'
+      NATAMI: 'ami-05b8dd01c6ff3ddda'
     'ap-east-1':
-      NATAMI: 'ami-06322b632e8ada1fa'
+      NATAMI: 'ami-0e728e9f7c6b7ab7f'
     'ap-southeast-1':
-      NATAMI: 'ami-0a3d7c296ebfff761'
+      NATAMI: 'ami-0e5ff9dcbc5a55508'
     'ap-southeast-2':
-      NATAMI: 'ami-015aff2ceba6d2b6e'
+      NATAMI: 'ami-07da08241e23b56ed'
     'eu-central-1':
-      NATAMI: 'ami-08ffe5c72a85c894d'
+      NATAMI: 'ami-0a50a8301f0e10fce'
     'us-east-1':
-      NATAMI: 'ami-00a36856283d67c39'
+      NATAMI: 'ami-070801f9b4d12d5dc'
     'us-east-2':
-      NATAMI: 'ami-0fbd30fcb05346f14'
+      NATAMI: 'ami-079d7a20b448f4d4d'
     'us-west-1':
-      NATAMI: 'ami-0046c079820366dc3'
+      NATAMI: 'ami-04f89cb3daa0e9134'
     'us-west-2':
-      NATAMI: 'ami-07516a08e3c79b372'
+      NATAMI: 'ami-0d88b34dd56682109'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/vpc/vpc-ssh-bastion.yaml
+++ b/vpc/vpc-ssh-bastion.yaml
@@ -91,47 +91,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/vpc/vpc-vpn-bastion.yaml
+++ b/vpc/vpc-vpn-bastion.yaml
@@ -133,47 +133,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -8,7 +8,7 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/wordpress
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20210813.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211001.1-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 ### Load Test

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -196,47 +196,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref WebServerKeyName, '']]

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -233,47 +233,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-03590d67411bbd24e'
+      AMI: 'ami-0cff8a37cfecca308'
     'eu-north-1':
-      AMI: 'ami-0f0b4cb72cf3eadf3'
+      AMI: 'ami-0d15082500b576303'
     'ap-south-1':
-      AMI: 'ami-0a23ccb2cdd9286bb'
+      AMI: 'ami-041d6256ed0f2061c'
     'eu-west-3':
-      AMI: 'ami-072056ff9d3689e7b'
+      AMI: 'ami-0eb34a1ff6bafc83f'
     'eu-west-2':
-      AMI: 'ami-0dbec48abfe298cab'
+      AMI: 'ami-02f5781cba46a5e8a'
     'eu-south-1':
-      AMI: 'ami-043c883e65558daa0'
+      AMI: 'ami-07b39d7b78c49db0c'
     'eu-west-1':
-      AMI: 'ami-0d1bf5b68307103c2'
+      AMI: 'ami-05cd35b907b4ffe77'
     'ap-northeast-3':
-      AMI: 'ami-09ec82600a05bc23a'
+      AMI: 'ami-0791d2e614355a9eb'
     'ap-northeast-2':
-      AMI: 'ami-08c64544f5cfcddd0'
+      AMI: 'ami-0e4a9ad2eb120e054'
     'me-south-1':
-      AMI: 'ami-0cc423da78c883d64'
+      AMI: 'ami-09982ea549a4b883e'
     'ap-northeast-1':
-      AMI: 'ami-02892a4ea9bfa2192'
+      AMI: 'ami-0701e21c502689c31'
     'sa-east-1':
-      AMI: 'ami-09b9b17384f68fd7c'
+      AMI: 'ami-05855ed85de7fbd77'
     'ca-central-1':
-      AMI: 'ami-0e2407e55b9816758'
+      AMI: 'ami-0a70476e631caa6d3'
     'ap-east-1':
-      AMI: 'ami-0de9d09f41c5e334c'
+      AMI: 'ami-0f9b476fca017b449'
     'ap-southeast-1':
-      AMI: 'ami-082105f875acab993'
+      AMI: 'ami-073998ba87e205747'
     'ap-southeast-2':
-      AMI: 'ami-0210560cedcb09f07'
+      AMI: 'ami-05c029a4b57edda9e'
     'eu-central-1':
-      AMI: 'ami-07df274a488ca9195'
+      AMI: 'ami-058e6df85cfc7760b'
     'us-east-1':
-      AMI: 'ami-087c17d1fe0178315'
+      AMI: 'ami-02e136e904f3da870'
     'us-east-2':
-      AMI: 'ami-00dfe2c7ce89a450b'
+      AMI: 'ami-074cce78125f09d61'
     'us-west-1':
-      AMI: 'ami-011996ff98de391d1'
+      AMI: 'ami-03ab7423a204da002'
     'us-west-2':
-      AMI: 'ami-0c2d06d50ce30b442'
+      AMI: 'ami-013a129d325529d4d'
   DBServerInstanceTypeMap:
     'db.t3.micro':
       PerformanceInsights: false


### PR DESCRIPTION
[Security] ecs/cluster* - Update Amazon Linux 2 ECS-optimized to 20210929
[Security] vpc/vpc-nat-instance - Update Amazon Linux NAT-optimized to 20211001.0
