### PR TITLE
[New Template] vpc/vpc-no-bastion

### DIFF
--- a/docs/vpc.md
+++ b/docs/vpc.md
@@ -134,7 +134,7 @@ Use `ssh -J $user@$bastion $target` and replace `$user` with your IAM user name;
 * Only one EC2 instance is managed by the ASG. In case of an outage the instance will be replaced within 5 minutes.
 
 # No bastion host/instance
-If you leave the `ParentSSHBastionStack` parameter blank in other templates, port 22 is open to the world `0.0.0.0/0`. This template can be used to disable SSH access by deploying an "empty" / non existant bastion host (e.g., when using SSM Session Manager).
+If you leave the `ParentSSHBastionStack` parameter blank in other templates, port 22 is open to the world `0.0.0.0/0`. This template can be used to disable SSH access by deploying an "empty" / non-existent bastion host (e.g., when using SSM Session Manager).
 
 ## Installation Guide
 1. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/vpc/vpc-no-bastion.yaml&stackName=no-bastion&param_ParentVPCStack=vpc)

--- a/docs/vpc.md
+++ b/docs/vpc.md
@@ -133,6 +133,18 @@ Use `ssh -J $user@$bastion $target` and replace `$user` with your IAM user name;
 ## Limitations
 * Only one EC2 instance is managed by the ASG. In case of an outage the instance will be replaced within 5 minutes.
 
+# No bastion host/instance
+If you leave the `ParentSSHBastionStack` parameter blank in other templates, port 22 is open to the world `0.0.0.0/0`. This template can be used to disable SSH access by deploying an "empty" / non existant bastion host (e.g., when using SSM Session Manager).
+
+## Installation Guide
+1. [![Launch Stack](./img/launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://s3-eu-west-1.amazonaws.com/widdix-aws-cf-templates-releases-eu-west-1/__VERSION__/vpc/vpc-no-bastion.yaml&stackName=no-bastion&param_ParentVPCStack=vpc)
+1. Click **Next** to proceed with the next step of the wizard.
+1. Specify a name and all parameters for the stack.
+1. Click **Next** to proceed with the next step of the wizard.
+1. Click **Next** to skip the **Options** step of the wizard.
+1. Click **Create** to start the creation of the stack.
+1. Wait until the stack reaches the state **CREATE_COMPLETE**
+
 # VPN bastion host/instance
 This template describes a **highly available** VPN bastion host/instance based on the [SoftEther VPN Project](https://www.softether.org).
 

--- a/vpc/vpc-no-bastion.yaml
+++ b/vpc/vpc-no-bastion.yaml
@@ -1,0 +1,48 @@
+---
+# Copyright 2018 widdix GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'VPC: No bastion host, a cloudonaut.io template'
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+    - Label:
+        default: 'Parent Stacks'
+      Parameters:
+      - ParentVPCStack
+Parameters:
+  ParentVPCStack:
+    Description: 'Stack name of parent VPC stack based on vpc/vpc-*azs.yaml template.'
+    Type: String
+Resources:
+  SecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Ref 'AWS::StackName'
+      VpcId: {'Fn::ImportValue': !Sub '${ParentVPCStack}-VPC'}
+Outputs:
+  TemplateID:
+    Description: 'cloudonaut.io template id.'
+    Value: 'vpc/vpc-no-bastion'
+  TemplateVersion:
+    Description: 'cloudonaut.io template version.'
+    Value: '__VERSION__'
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+  SecurityGroup:
+    Description: 'Use this Security Group to reference incoming traffic from the bastion host/instance.'
+    Value: !Ref SecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-SecurityGroup'


### PR DESCRIPTION
This template can be used to disable SSH access by deploying an "empty" / non existant bastion host (e.g., when using SSM Session Manager).

