### PR TITLE
[Security] * - Update Amazon Linux 2 to 20211201.0

### DIFF
--- a/ec2/README.md
+++ b/ec2/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/ec2/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211103.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/ecs/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-ecs-hvm-2.0.20211115-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  ECSAMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-ecs-hvm-2.0.20211120-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  ECSAMI: '$ami'\n"; done
 ```

--- a/ecs/cluster-cost-optimized.yaml
+++ b/ecs/cluster-cost-optimized.yaml
@@ -175,47 +175,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      ECSAMI: 'ami-0336549c44ef3e745'
+      ECSAMI: 'ami-0d136a9aa2ac32679'
     'eu-north-1':
-      ECSAMI: 'ami-09666749b685f34d5'
+      ECSAMI: 'ami-0f541966b45340fce'
     'ap-south-1':
-      ECSAMI: 'ami-000e4b3f0c9f06ffb'
+      ECSAMI: 'ami-00c7dbcc1310fd066'
     'eu-west-3':
-      ECSAMI: 'ami-04cb3664fdfc392bd'
+      ECSAMI: 'ami-0bce8e5f8fd912af2'
     'eu-west-2':
-      ECSAMI: 'ami-0141564f07476504d'
+      ECSAMI: 'ami-02a7ca2a9d03676bf'
     'eu-south-1':
-      ECSAMI: 'ami-0e6b2162879794cd7'
+      ECSAMI: 'ami-08cfcfe946c46ac2f'
     'eu-west-1':
-      ECSAMI: 'ami-015b1508a2ff2c65a'
+      ECSAMI: 'ami-02c55114d1d2a8201'
     'ap-northeast-3':
-      ECSAMI: 'ami-076a5e56139b78983'
+      ECSAMI: 'ami-02d358004635cea15'
     'ap-northeast-2':
-      ECSAMI: 'ami-0273b23020d7a59de'
+      ECSAMI: 'ami-0dcf592770858a733'
     'me-south-1':
-      ECSAMI: 'ami-03baaff13a9650078'
+      ECSAMI: 'ami-0c9239fc990a592fc'
     'ap-northeast-1':
-      ECSAMI: 'ami-04bbc04d168366d27'
+      ECSAMI: 'ami-0a428a8bcfce0f804'
     'sa-east-1':
-      ECSAMI: 'ami-003a04511c336560c'
+      ECSAMI: 'ami-035b4cb75ab88f259'
     'ca-central-1':
-      ECSAMI: 'ami-092b596d9b942c4f8'
+      ECSAMI: 'ami-0583af09af7e435f3'
     'ap-east-1':
-      ECSAMI: 'ami-068d6ef576369ad4f'
+      ECSAMI: 'ami-0121ac62cef6cd38b'
     'ap-southeast-1':
-      ECSAMI: 'ami-071fbc655b2398016'
+      ECSAMI: 'ami-09df7bed19956d10b'
     'ap-southeast-2':
-      ECSAMI: 'ami-032edebfa34883542'
+      ECSAMI: 'ami-0666dd0a9eccbab7d'
     'eu-central-1':
-      ECSAMI: 'ami-097b8c9927f9a27bc'
+      ECSAMI: 'ami-0e8f6957a4eb67446'
     'us-east-1':
-      ECSAMI: 'ami-01783fbb0757adced'
+      ECSAMI: 'ami-0fe19057e9cb4efd8'
     'us-east-2':
-      ECSAMI: 'ami-0adc4758ea76442e2'
+      ECSAMI: 'ami-086e001f1a73d208c'
     'us-west-1':
-      ECSAMI: 'ami-00becdb34b62bf459'
+      ECSAMI: 'ami-0bd3976c0dbacc605'
     'us-west-2':
-      ECSAMI: 'ami-09f043c293281ecd4'
+      ECSAMI: 'ami-04e6179c63d17513d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/ecs/cluster.yaml
+++ b/ecs/cluster.yaml
@@ -207,47 +207,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      ECSAMI: 'ami-0336549c44ef3e745'
+      ECSAMI: 'ami-0d136a9aa2ac32679'
     'eu-north-1':
-      ECSAMI: 'ami-09666749b685f34d5'
+      ECSAMI: 'ami-0f541966b45340fce'
     'ap-south-1':
-      ECSAMI: 'ami-000e4b3f0c9f06ffb'
+      ECSAMI: 'ami-00c7dbcc1310fd066'
     'eu-west-3':
-      ECSAMI: 'ami-04cb3664fdfc392bd'
+      ECSAMI: 'ami-0bce8e5f8fd912af2'
     'eu-west-2':
-      ECSAMI: 'ami-0141564f07476504d'
+      ECSAMI: 'ami-02a7ca2a9d03676bf'
     'eu-south-1':
-      ECSAMI: 'ami-0e6b2162879794cd7'
+      ECSAMI: 'ami-08cfcfe946c46ac2f'
     'eu-west-1':
-      ECSAMI: 'ami-015b1508a2ff2c65a'
+      ECSAMI: 'ami-02c55114d1d2a8201'
     'ap-northeast-3':
-      ECSAMI: 'ami-076a5e56139b78983'
+      ECSAMI: 'ami-02d358004635cea15'
     'ap-northeast-2':
-      ECSAMI: 'ami-0273b23020d7a59de'
+      ECSAMI: 'ami-0dcf592770858a733'
     'me-south-1':
-      ECSAMI: 'ami-03baaff13a9650078'
+      ECSAMI: 'ami-0c9239fc990a592fc'
     'ap-northeast-1':
-      ECSAMI: 'ami-04bbc04d168366d27'
+      ECSAMI: 'ami-0a428a8bcfce0f804'
     'sa-east-1':
-      ECSAMI: 'ami-003a04511c336560c'
+      ECSAMI: 'ami-035b4cb75ab88f259'
     'ca-central-1':
-      ECSAMI: 'ami-092b596d9b942c4f8'
+      ECSAMI: 'ami-0583af09af7e435f3'
     'ap-east-1':
-      ECSAMI: 'ami-068d6ef576369ad4f'
+      ECSAMI: 'ami-0121ac62cef6cd38b'
     'ap-southeast-1':
-      ECSAMI: 'ami-071fbc655b2398016'
+      ECSAMI: 'ami-09df7bed19956d10b'
     'ap-southeast-2':
-      ECSAMI: 'ami-032edebfa34883542'
+      ECSAMI: 'ami-0666dd0a9eccbab7d'
     'eu-central-1':
-      ECSAMI: 'ami-097b8c9927f9a27bc'
+      ECSAMI: 'ami-0e8f6957a4eb67446'
     'us-east-1':
-      ECSAMI: 'ami-01783fbb0757adced'
+      ECSAMI: 'ami-0fe19057e9cb4efd8'
     'us-east-2':
-      ECSAMI: 'ami-0adc4758ea76442e2'
+      ECSAMI: 'ami-086e001f1a73d208c'
     'us-west-1':
-      ECSAMI: 'ami-00becdb34b62bf459'
+      ECSAMI: 'ami-0bd3976c0dbacc605'
     'us-west-2':
-      ECSAMI: 'ami-09f043c293281ecd4'
+      ECSAMI: 'ami-04e6179c63d17513d'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/jenkins/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211103.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -219,47 +219,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasZeroAgents: !Equals [!Ref AgentMinSize, '0']

--- a/jenkins/jenkins2-ha.yaml
+++ b/jenkins/jenkins2-ha.yaml
@@ -167,47 +167,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/security/README.md
+++ b/security/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/security/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211103.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/security/auth-proxy-ha-github-orga.yaml
+++ b/security/auth-proxy-ha-github-orga.yaml
@@ -145,47 +145,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -9,10 +9,10 @@ To update the region map execute the following lines in your terminal:
 
 #### AMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211103.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 #### NATAMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn-ami-vpc-nat-2018.03.0.20211015.1-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  NATAMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn-ami-vpc-nat-2018.03.0.20211201.0-x86_64-ebs" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  NATAMI: '$ami'\n"; done
 ```

--- a/vpc/vpc-nat-instance.yaml
+++ b/vpc/vpc-nat-instance.yaml
@@ -99,47 +99,47 @@ Parameters:
 Mappings:
   RegionMap: # TODO update to Amazon Linux 2 (don't forget to adjust awslogs config as well)
     'af-south-1':
-      NATAMI: 'ami-042197706f7b2ecee'
+      NATAMI: 'ami-04ce1c3a0c6cec82c'
     'eu-north-1':
-      NATAMI: 'ami-07755a701b05eeff9'
+      NATAMI: 'ami-010da593b9ab722f3'
     'ap-south-1':
-      NATAMI: 'ami-01d96ef1c8ccff903'
+      NATAMI: 'ami-0d2c3fd049e018606'
     'eu-west-3':
-      NATAMI: 'ami-0aaa3422c73386428'
+      NATAMI: 'ami-0cbb966fc7c60d9fa'
     'eu-west-2':
-      NATAMI: 'ami-01b9b4a63d1f484a2'
+      NATAMI: 'ami-014fc84973768d5ca'
     'eu-south-1':
-      NATAMI: 'ami-0e2d4aa9141880d0d'
+      NATAMI: 'ami-05de37eab17b95f62'
     'eu-west-1':
-      NATAMI: 'ami-097ef3ce5c40814f2'
+      NATAMI: 'ami-094e52fbe4d11f464'
     'ap-northeast-3':
-      NATAMI: 'ami-0fb2ebeecceb00739'
+      NATAMI: 'ami-0237272767c78b1b5'
     'ap-northeast-2':
-      NATAMI: 'ami-075559fec6991df73'
+      NATAMI: 'ami-0bb7c1c8a8dac62c9'
     'me-south-1':
-      NATAMI: 'ami-040034da08cbc69f0'
+      NATAMI: 'ami-058ef0c5076d9e681'
     'ap-northeast-1':
-      NATAMI: 'ami-0a855f2e323191702'
+      NATAMI: 'ami-08219c3a94ae861a2'
     'sa-east-1':
-      NATAMI: 'ami-0c2fdacec03d745e8'
+      NATAMI: 'ami-047e83ebd246078ab'
     'ca-central-1':
-      NATAMI: 'ami-07d28adadef668265'
+      NATAMI: 'ami-096e549b999437694'
     'ap-east-1':
-      NATAMI: 'ami-05f389ea4885468a2'
+      NATAMI: 'ami-06e422178d18d6b6f'
     'ap-southeast-1':
-      NATAMI: 'ami-0c00566f9eed3a3f0'
+      NATAMI: 'ami-00567b84cbb1f3832'
     'ap-southeast-2':
-      NATAMI: 'ami-06ff96e5c4a34bff6'
+      NATAMI: 'ami-036785920b4cd3a87'
     'eu-central-1':
-      NATAMI: 'ami-0aa2f7dc4e37f9282'
+      NATAMI: 'ami-0dde402e037cd83f3'
     'us-east-1':
-      NATAMI: 'ami-0822796fd7b3ba710'
+      NATAMI: 'ami-04e5df0cf5946b2a4'
     'us-east-2':
-      NATAMI: 'ami-09d6514316ddbd062'
+      NATAMI: 'ami-0ff31eaee89e82e73'
     'us-west-1':
-      NATAMI: 'ami-0e71439d438f51690'
+      NATAMI: 'ami-0c430b1497bab4641'
     'us-west-2':
-      NATAMI: 'ami-0889d9089a8b74971'
+      NATAMI: 'ami-01fe3719e28227524'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/vpc/vpc-ssh-bastion.yaml
+++ b/vpc/vpc-ssh-bastion.yaml
@@ -91,47 +91,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/vpc/vpc-vpn-bastion.yaml
+++ b/vpc/vpc-vpn-bastion.yaml
@@ -133,47 +133,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref KeyName, '']]

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -8,7 +8,7 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/wordpress
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211103.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20211201.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 ### Load Test

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -196,47 +196,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasKeyName: !Not [!Equals [!Ref WebServerKeyName, '']]

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -233,47 +233,47 @@ Parameters:
 Mappings:
   RegionMap:
     'af-south-1':
-      AMI: 'ami-0a1a86ded8c9e43c9'
+      AMI: 'ami-09fa0d72d00d79024'
     'eu-north-1':
-      AMI: 'ami-08b0de3847e24ff84'
+      AMI: 'ami-05bc2576a72f22c39'
     'ap-south-1':
-      AMI: 'ami-0f1fb91a596abf28d'
+      AMI: 'ami-0002bdad91f793433'
     'eu-west-3':
-      AMI: 'ami-05f0a049e7aeb407c'
+      AMI: 'ami-0c73cd1c5347436f3'
     'eu-west-2':
-      AMI: 'ami-0fc15d50d39e4503c'
+      AMI: 'ami-029ed17b4ea379178'
     'eu-south-1':
-      AMI: 'ami-083ac1226d02e6211'
+      AMI: 'ami-02363ede7f44e6bf2'
     'eu-west-1':
-      AMI: 'ami-09d4a659cdd8677be'
+      AMI: 'ami-04632f3cef5083854'
     'ap-northeast-3':
-      AMI: 'ami-0d9649ef6deb663a7'
+      AMI: 'ami-0ae88850834d2c589'
     'ap-northeast-2':
-      AMI: 'ami-0a5a6128e65676ebb'
+      AMI: 'ami-0263588f2531a56bd'
     'me-south-1':
-      AMI: 'ami-09a2e6e8686165092'
+      AMI: 'ami-02fe70db14497ff34'
     'ap-northeast-1':
-      AMI: 'ami-0e60b6d05dc38ff11'
+      AMI: 'ami-0abaa5b0faf689830'
     'sa-east-1':
-      AMI: 'ami-03a343b9045171cec'
+      AMI: 'ami-053a035b046dbb704'
     'ca-central-1':
-      AMI: 'ami-0730e12069ab20c26'
+      AMI: 'ami-0173297cea9ba27b0'
     'ap-east-1':
-      AMI: 'ami-010eef29fc1fb56b0'
+      AMI: 'ami-0a7fb2d401b6017e5'
     'ap-southeast-1':
-      AMI: 'ami-024221a59c9020e72'
+      AMI: 'ami-0d1d4b8d5a0cd293f'
     'ap-southeast-2':
-      AMI: 'ami-043e0add5c8665836'
+      AMI: 'ami-0f4484f62c4fd8767'
     'eu-central-1':
-      AMI: 'ami-030e490c34394591b'
+      AMI: 'ami-099ccc441b2ef41ec'
     'us-east-1':
-      AMI: 'ami-04ad2567c9e3d7893'
+      AMI: 'ami-061ac2e015473fbe2'
     'us-east-2':
-      AMI: 'ami-0dd0ccab7e2801812'
+      AMI: 'ami-056b1936002ca8ede'
     'us-west-1':
-      AMI: 'ami-0074ef78ecb07948c'
+      AMI: 'ami-028f2b5ee08012131'
     'us-west-2':
-      AMI: 'ami-00be885d550dcee43'
+      AMI: 'ami-0e21d4d9303512b8e'
   DBServerInstanceTypeMap:
     'db.t3.micro':
       PerformanceInsights: false


### PR DESCRIPTION
[Security] ecs/cluster* - Update Amazon Linux 2 ECS-optimized to 20211120
[Security] vpc/vpc-nat-instance - Update Amazon Linux NAT-optimized to 20211201.1
