### PR TITLE
fix: invalid source for ECS events

### DIFF
--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -469,7 +469,7 @@ Resources:
     Properties:
       EventPattern:
         source:
-        - 'aws.ec2'
+        - 'aws.ecs'
         'detail-type':
         - 'ECS Service Action'
         resources:


### PR DESCRIPTION
Should be `aws.ecs` according to the [schema](https://eu-central-1.console.aws.amazon.com/events/home?region=eu-central-1#/registries/aws.events/schemas/aws.ecs%40ECSServiceAction/version/1)