### PR TITLE
Evergreen command to fetch latest AMIs

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/jenkins/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20220426.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ssm get-parameters --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 --query "Parameters[0].Value" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/security/README.md
+++ b/security/README.md
@@ -8,5 +8,5 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/security/
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20220426.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ssm get-parameters --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 --query "Parameters[0].Value" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -9,7 +9,7 @@ To update the region map execute the following lines in your terminal:
 
 #### AMI
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20220426.0.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ssm get-parameters --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 --query "Parameters[0].Value" --output "text"); printf "'$region':\n  AMI: '$ami'\n"; done
 ```
 
 #### NATAMI

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -8,7 +8,7 @@ Find the documentation here: https://templates.cloudonaut.io/en/stable/wordpress
 To update the region map execute the following lines in your terminal:
 
 ```
-for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20220426.0-x86_64-gp2" --query "Images[0].ImageId" --output "text"); prefix_cf=$(aws --region $region ec2 describe-managed-prefix-lists --filters "Name=prefix-list-name,Values=com.amazonaws.global.cloudfront.origin-facing" --query "PrefixLists[0].PrefixListId" --output "text"); printf "'$region':\n  AMI: '$ami'\n  PrefixListCloudFront: '$prefix_cf'\n"; done
+for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do ami=$(aws --region $region ssm get-parameters --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 --query "Parameters[0].Value" --output "text"); prefix_cf=$(aws --region $region ec2 describe-managed-prefix-lists --filters "Name=prefix-list-name,Values=com.amazonaws.global.cloudfront.origin-facing" --query "PrefixLists[0].PrefixListId" --output "text"); printf "'$region':\n  AMI: '$ami'\n  PrefixListCloudFront: '$prefix_cf'\n"; done
 ```
 
 ### Load Test


### PR DESCRIPTION
Referencing the Bash script under "Querying for the latest AMI using public parameters" at https://aws.amazon.com/blogs/compute/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/

I can see that

aws --region us-east-1 ssm get-parameters --names /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2 --query "Parameters[0].Value"

has the same output as

aws --region us-east-1 ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-2.0.20220426.0-x86_64-gp2" --query "Images[0].ImageId"

but doesn't use the exact AMI revision in the command, which seems more future-proof.