### PR TITLE
[Improvement] state/dynamodb - Support advanced features for AWS Backup DynamoDB backups

### DIFF
--- a/state/dynamodb.yaml
+++ b/state/dynamodb.yaml
@@ -729,6 +729,8 @@ Resources:
             Action:
             - 'dynamodb:DescribeTable'
             - 'dynamodb:CreateBackup'
+            - 'dynamodb:ListTagsOfResource'
+            - 'dynamodb:StartAwsBackupJob'
             Resource: !GetAtt 'Table.Arn'
           - Effect: Allow
             Action:


### PR DESCRIPTION
Template: state/dynamodb.yaml

DynamoDB backup jobs were failing, stating that first, dynamodb:ListTagsOfResource was required, then, dynamodb:StartAwsBackupJob was required.

Once these Actions were allowed for the Role, DynamoDB backups started and completed as expected.

https://docs.aws.amazon.com/aws-backup/latest/devguide/security-iam-awsmanpol.html mentions both of these being added to the AWS Backup policy, under "Policy updates for AWS Backup", Date "November 23, 2021"

The specific errors were:

An AWS Backup job failed. Resource ARN : arn:aws:dynamodb:us-west-1:XXXXXXXXXXXX:table/cache. BackupJob ID : XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX Status Message : User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/XXXXXXX-com-DynamoDB-BackupRole-XXXXXXXXXXXXX/AWSBackup-XXXXXXX-com-DynamoDB-BackupRole-XXXXXXXXXXXXX is not authorized to perform: dynamodb:ListTagsOfResource on resource: arn:aws:dynamodb:us-west-1:XXXXXXXXXXXX:table/cache because no identity-based policy allows the dynamodb:ListTagsOfResource action

then

An AWS Backup job failed. Resource ARN : arn:aws:dynamodb:us-west-1:XXXXXXXXXXXX:table/cache. BackupJob ID : XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX Status Message : User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/XXXXXXX-com-DynamoDB-cache-BackupRole-XXXXXXXXXXXX/AWSBackup-XXXXXXX-com-DynamoDB-cache-BackupRole-XXXXXXXXXXXX is not authorized to perform: dynamodb:StartAwsBackupJob on resource: arn:aws:dynamodb:us-west-1:XXXXXXXXXXXX:table/cache because no identity-based policy allows the dynamodb:StartAwsBackupJob action