### PR TITLE
Adding custom health check paths for ALB

### DIFF
--- a/ecs/service-cluster-alb.yaml
+++ b/ecs/service-cluster-alb.yaml
@@ -44,6 +44,7 @@ Metadata:
       - MaxCapacity
       - MinCapacity
       - HealthCheckGracePeriod
+      - HealthCheckPath
     - Label:
         default: 'Permission Parameters'
       Parameters:
@@ -133,6 +134,10 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
+  HealthCheckPath:
+    Description: 'Path of health check'
+    Type: String
+    Default: '/'
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasLoadBalancerHttps: !Equals [!Ref LoadBalancerHttps, 'true']
@@ -191,7 +196,7 @@ Resources:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckIntervalSeconds: 15
-      HealthCheckPath: '/'
+      HealthCheckPath: !Ref HealthCheckPath
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 2

--- a/ecs/service-dedicated-alb.yaml
+++ b/ecs/service-dedicated-alb.yaml
@@ -47,6 +47,7 @@ Metadata:
       - MaxCapacity
       - MinCapacity
       - HealthCheckGracePeriod
+      - HealthCheckPath
     - Label:
         default: 'Permission Parameters'
       Parameters:
@@ -142,6 +143,11 @@ Parameters:
     Default: 60
     MinValue: 0
     MaxValue: 1800
+  HealthCheckPath:
+    Description: 'Path of health check'
+    Type: String
+    Default: '/'
+
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
   HasAuthProxySecurityGroup: !Not [!Equals [!Ref ParentAuthProxyStack, '']]
@@ -248,7 +254,7 @@ Resources:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckIntervalSeconds: 15
-      HealthCheckPath: '/'
+      HealthCheckPath: !Ref HealthCheckPath
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 2


### PR DESCRIPTION
Currently the ALB only check the root '/' path for health checking. Some images require a custom health check path and is supported by AWS cli / console / cloudformation as well.
