### PR TITLE
[Bug Fix] state/s3 - Fix Access := CloudFrontAccessLogWrite

### DIFF
--- a/state/s3.yaml
+++ b/state/s3.yaml
@@ -181,6 +181,7 @@ Resources:
         - !If [HasLambdaFunctionArn, {Event: !Ref LambdaFunctionEvent, Function: !Ref LambdaFunctionArn, Filter: !If [HasLambdaFunctionFilterPrefix, {S3Key: {Rules: [{Name: prefix, Value: !Ref LambdaFunctionFilterPrefix}]}}, !Ref 'AWS::NoValue']}, !Ref 'AWS::NoValue']
         QueueConfigurations:
         - !If [HasS3VirusScan, {Event: 's3:ObjectCreated:*', Queue: {'Fn::ImportValue': !Sub '${ParentS3VirusScanStack}-ScanQueueArn'}}, !Ref 'AWS::NoValue']
+      OwnershipControls: !If [HasCloudFrontAccessLogWrite, {Rules: [{ObjectOwnership: BucketOwnerPreferred}]}, !Ref 'AWS::NoValue']
       PublicAccessBlockConfiguration: !If [HasPublicAccessBlock, {BlockPublicAcls: true, BlockPublicPolicy: true, IgnorePublicAcls: true, RestrictPublicBuckets: true}, !Ref 'AWS::NoValue'] # AWS Foundational Security Best Practices v1.0.0 S3.8
       VersioningConfiguration: !If [HasVersioning, {Status: Enabled}, !If [HadVersioning, {Status: Suspended}, !Ref 'AWS::NoValue']]
       BucketEncryption:

--- a/test/src/test/java/de/widdix/awscftemplates/operations/TestAccessLogsAnonymizer.java
+++ b/test/src/test/java/de/widdix/awscftemplates/operations/TestAccessLogsAnonymizer.java
@@ -55,7 +55,7 @@ public class TestAccessLogsAnonymizer extends ACloudFormationTest {
                 final String functionARN = this.getStackOutputValue(anonymizerStackName, "FunctionARN");
                 this.updateStack(context, s3StackName,
                         "state/s3.yaml",
-                        new Parameter().withParameterKey("Access").withParameterValue("CloudFrontAccessLogWrite"),
+                        new Parameter().withParameterKey("Access").withParameterValue("ElbAccessLogWrite"),
                         new Parameter().withParameterKey("LambdaFunctionArn").withParameterValue(functionARN)
                 );
                 // TODO upload file and test if IP addresses are anonymized


### PR DESCRIPTION
Broken because of the switch in S3 to disable ACLs by default.