### PR TITLE
copy tags to cluster snapshots

### DIFF
--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -290,6 +290,7 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     Properties:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
+      CopyTagsToSnapshot: true
       DatabaseName: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBName]
       DBClusterParameterGroupName: !Ref DBClusterParameterGroup
       DBSubnetGroupName: !Ref DBSubnetGroup


### PR DESCRIPTION
`CopyTagsToSnapshot` is now supported on `AWS::RDS::DBCluster` resource(s).

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

`CopyTagsToSnapshot` is now supported on `AWS::RDS::DBCluster` resource(s):
- https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/238
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-copytagstosnapshot
