### PR TITLE
Allow CloudFront to serve encrypted content from S3

### DIFF
--- a/security/kms-key.yaml
+++ b/security/kms-key.yaml
@@ -40,6 +40,7 @@ Parameters:
     - 'S3_PUBLIC_ACCESS'
     - 'ROUTE53_DNSSEC'
     - 'CLOUDTRAIL'
+    - 'CLOUDFRONT'
     - connect
     - dms
     - ssm
@@ -87,8 +88,9 @@ Conditions:
   HasServiceAllServices: !Equals [!Ref Service, 'ALL_SERVICES']
   HasServiceS3PublicAccess: !Equals [!Ref Service, 'S3_PUBLIC_ACCESS']
   HasServiceRoute53Dnssec: !Or [!Equals [!Ref Service, 'ROUTE53_DNSSEC'], !Equals [!Ref Service, 'dnssec-route53']]
+  HasServiceCloudFront: !Equals [!Ref Service, 'CLOUDFRONT']
   HasServiceCloudTrail: !Equals [!Ref Service, 'CLOUDTRAIL']
-  HasService: !Not [!Or [!Condition HasServiceAllServices, !Condition HasServiceS3PublicAccess, !Condition HasServiceRoute53Dnssec, !Condition HasServiceCloudTrail]]
+  HasService: !Not [!Or [!Condition HasServiceAllServices, !Condition HasServiceS3PublicAccess, !Condition HasServiceRoute53Dnssec, !Condition HasServiceCloudFront, !Condition HasServiceCloudTrail]]
   HasSymmetricKey: !Equals [!Ref KeySpec, 'SYMMETRIC_DEFAULT']
 Resources:
   Key:
@@ -190,6 +192,20 @@ Resources:
             Condition:
               StringLike:
                 'kms:EncryptionContext:aws:cloudtrail:arn': !Sub 'arn:aws:cloudtrail:*:${AWS::AccountId}:trail/*'
+          - !Ref 'AWS::NoValue'
+        - !If
+          - HasServiceCloudFront
+          - Effect: Allow # https://aws.amazon.com/blogs/networking-and-content-delivery/serving-sse-kms-encrypted-content-from-s3-using-cloudfront/
+            Principal:
+              Service: 'cloudfront.amazonaws.com'
+            Action:
+            - 'kms:Decrypt'
+            - 'kms:Encrypt'
+            - 'kms:GenerateDataKey*'
+            Resource: '*'
+            Condition:
+              StringLike:
+                'aws:SourceArn': !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
           - !Ref 'AWS::NoValue'
   KeyAlias:
     DeletionPolicy: Retain

--- a/security/kms-key.yaml
+++ b/security/kms-key.yaml
@@ -200,8 +200,6 @@ Resources:
               Service: 'cloudfront.amazonaws.com'
             Action:
             - 'kms:Decrypt'
-            - 'kms:Encrypt'
-            - 'kms:GenerateDataKey*'
             Resource: '*'
             Condition:
               StringLike:


### PR DESCRIPTION
**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

Allow CloudFront to service encrypted content from S3 origins. See,  https://aws.amazon.com/blogs/networking-and-content-delivery/serving-sse-kms-encrypted-content-from-s3-using-cloudfront/