### PR TITLE
enforce KMS-SSE requests to CloudTrail bucket

### DIFF
--- a/security/cloudtrail.yaml
+++ b/security/cloudtrail.yaml
@@ -215,6 +215,20 @@ Resources:
           Condition:
             Bool:
               'aws:SecureTransport': false
+        - !If
+          - HasParentKmsKeyStack
+          - Sid: EnforceSSERequests
+            Principal: '*'
+            Action: 's3:PutObject*'
+            Effect: Deny
+            Resource: !If [HasLogFilePrefix, !Sub 'arn:aws:s3:::${TrailBucket}/${LogFilePrefix}/AWSLogs/${AWS::AccountId}/*', !Sub 'arn:aws:s3:::${TrailBucket}/AWSLogs/${AWS::AccountId}/*']
+            Condition:
+              StringNotEquals:
+                's3:x-amz-server-side-encryption':
+                - 'AES256'
+                - 'aws:kms'
+                's3:x-amz-server-side-encryption-aws-kms-key-id': {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyArn'}
+          - !Ref 'AWS::NoValue'
   TrailLogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:

--- a/security/kms-key.yaml
+++ b/security/kms-key.yaml
@@ -188,6 +188,7 @@ Resources:
               Service: 'cloudtrail.amazonaws.com'
             Action:
             - 'kms:GenerateDataKey*'
+            - 'kms:DescribeKey'
             Resource: '*'
             Condition:
               StringLike:


### PR DESCRIPTION
**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

Add bucket policy to enforce encryption by default using S3-SSE key. Required by ISO 27001 2022/SOC 2/GDPR controls:
* AC-10
* C-01
* GDPR-15
* GDPR-23