### PR TITLE
allow CloudFront logging to access KMS key

### DIFF
--- a/security/kms-key.yaml
+++ b/security/kms-key.yaml
@@ -62,6 +62,7 @@ Parameters:
     - workspaces
     - dnssec-route53 # Deprecated since v13. Will be removed in v15. Use ROUTE53_DNSSEC instead.
     - cloudtrail
+    - cloudfront-logs
     Default: ALL_SERVICES
   KeySpec:
     Description: 'Specify the type of the CMK.'
@@ -89,6 +90,7 @@ Conditions:
   HasServiceS3PublicAccess: !Equals [!Ref Service, 'S3_PUBLIC_ACCESS']
   HasServiceRoute53Dnssec: !Or [!Equals [!Ref Service, 'ROUTE53_DNSSEC'], !Equals [!Ref Service, 'dnssec-route53']]
   HasServiceCloudFront: !Equals [!Ref Service, 'CLOUDFRONT']
+  HasServiceCloudFrontLogs: !Equals [!Ref Service, 'cloudfront-logs']
   HasServiceCloudTrail: !Equals [!Ref Service, 'CLOUDTRAIL']
   HasService: !Not [!Or [!Condition HasServiceAllServices, !Condition HasServiceS3PublicAccess, !Condition HasServiceRoute53Dnssec, !Condition HasServiceCloudFront, !Condition HasServiceCloudTrail]]
   HasSymmetricKey: !Equals [!Ref KeySpec, 'SYMMETRIC_DEFAULT']
@@ -204,6 +206,16 @@ Resources:
             Condition:
               StringLike:
                 'aws:SourceArn': !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
+          - !Ref 'AWS::NoValue'
+        - !If
+          - HasServiceCloudFrontLogs
+          - Effect: Allow # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsKMSPermissions
+            Principal:
+              Service: 'delivery.logs.amazonaws.com'
+            Action:
+            - 'kms:GenerateDataKey*'
+            - 'kms:Decrypt'
+            Resource: '*'
           - !Ref 'AWS::NoValue'
   KeyAlias:
     DeletionPolicy: Retain


### PR DESCRIPTION
CloudFront doesn't appear to (currently) set SSE/KMS parameters on its access log write requests to S3, so a deny policy prevents logs from being written, even though encryption would happen regardless.

**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

---

allow CloudFront to use [SSE-KMS to write access logs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsKMSPermissions) to such buckets (using bucket keys)
