### PR TITLE
Allow setting transfer acceleration

### DIFF
--- a/state/s3.yaml
+++ b/state/s3.yaml
@@ -29,6 +29,7 @@ Metadata:
       Parameters:
       - BucketName
       - Access
+      - TransferAcceleration
       - Versioning
       - NoncurrentVersionExpirationInDays
       - ExpirationInDays
@@ -73,6 +74,11 @@ Parameters:
     Type: String
     Default: Private
     AllowedValues: [Private, PublicRead, PublicWrite, PublicReadAndWrite, CloudFrontRead, CloudFrontAccessLogWrite, ElbAccessLogWrite, ElbAccessLogWriteEncrypted, S3AccessLogWrite, ConfigWrite, CloudTrailWrite, VpcEndpointRead, FlowLogWrite]
+  TransferAcceleration:
+    Description: 'Specifies the transfer acceleration status of the bucket.'
+    Type: String
+    Default: Suspended
+    AllowedValues: [Enabled, Suspended]
   Versioning:
     Description: 'Enable versioning to keep a backup if objects change.'
     Type: String
@@ -168,6 +174,8 @@ Resources:
       BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
       LoggingConfiguration: !If [HasS3Bucket, {DestinationBucketName: {'Fn::ImportValue': !Sub '${ParentS3StackAccessLog}-BucketName'}, LogFilePrefix: !Ref 'AWS::StackName'}, !Ref 'AWS::NoValue']
       AccessControl: !If [HasS3AccessLogWrite, LogDeliveryWrite, !Ref 'AWS::NoValue']
+      AccelerateConfiguration:
+        AccelerationStatus: !Ref TransferAcceleration
       LifecycleConfiguration:
         Rules:
         - AbortIncompleteMultipartUpload:


### PR DESCRIPTION
**(Override all values in parentheses)**

(Run `yamllint folder/template.yaml`, `cfn-lint -i E1019 E3002 E2520 -t folder/template.yaml`, and `aws cloudformation validate-template --template-body file://folder/template.yaml` before you open a PR)

(Do not include multiple changes in one PR. Open additional PRs instead.)

```
# addressing this should be a separate PR
$ cfn-lint -i E1019 E3002 E2520 -t state/s3.yaml 
W3045 Consider using AWS::S3::BucketPolicy instead of AccessControl
state/s3.yaml:176:7
```

---

S3 buckets can be [accelerated](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html) to allow workloads in different regions to practically share a bucket in a central region. This change allows toggling this feature on (default off).