### PR TITLE
[Security] ec2/* - Require IMDSv2

### DIFF
--- a/ec2/al2-mutable-private.yaml
+++ b/ec2/al2-mutable-private.yaml
@@ -1219,7 +1219,7 @@ Resources:
           - 'iam:GetSSHPublicKey'
           Resource:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:user/*'
-  VirtualMachine: # TODO make IMDSv2 required (waits for https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/655)
+  VirtualMachine:
     Type: 'AWS::EC2::Instance'
     Metadata:
       'AWS::CloudFormation::Init':
@@ -1470,6 +1470,8 @@ Resources:
       ImageId: !If [HasRestoreImageId, !Ref RestoreImageId, !FindInMap [!FindInMap [VersionMap, !Ref AmazonLinux2Version, Map], !Ref 'AWS::Region', AMI]]
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      MetadataOptions:
+        HttpTokens: required
       BlockDeviceMappings:
       - DeviceName: '/dev/xvda'
         Ebs:

--- a/ec2/al2-mutable-public.yaml
+++ b/ec2/al2-mutable-public.yaml
@@ -1228,7 +1228,7 @@ Resources:
           - 'iam:GetSSHPublicKey'
           Resource:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:user/*'
-  VirtualMachine: # TODO make IMDSv2 required (waits for https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/655)
+  VirtualMachine:
     DependsOn: EIPAssociation
     Type: 'AWS::EC2::Instance'
     Metadata:
@@ -1480,6 +1480,8 @@ Resources:
       ImageId: !If [HasRestoreImageId, !Ref RestoreImageId, !FindInMap [!FindInMap [VersionMap, !Ref AmazonLinux2Version, Map], !Ref 'AWS::Region', AMI]]
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      MetadataOptions:
+        HttpTokens: required
       BlockDeviceMappings:
       - DeviceName: '/dev/xvda'
         Ebs:


### PR DESCRIPTION
Finally supported by CloudFormation after 5 years, see https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/655)
