### PR TITLE
fix: Upgrade CloudFront TLS config to TLSv1.2_2021

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         yamllint .
     - name: cfn-lint
       run: |
-        pip install cfn-lint==1.39.1
+        pip install cfn-lint==1.44.0
         cfn-lint -i E1022 E3003 E3014 E3026 E3032 W1011 W2001 W2010 W3045 W6001 W8003 -t '**/*.yaml'
     - name: license
       run: |

--- a/static-website/static-website.yaml
+++ b/static-website/static-website.yaml
@@ -275,7 +275,7 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !If [HasCreateAcmCertificate, !Ref Certificate, !If [HasAcmCertificateArn, !Ref ExistingCertificate, !Ref 'AWS::NoValue']]
           IamCertificateId: !If [HasIamCertificateId, !Ref ExistingCertificate, !Ref 'AWS::NoValue']
-          MinimumProtocolVersion: 'TLSv1.2_2019'
+          MinimumProtocolVersion: 'TLSv1.2_2025'
           SslSupportMethod: 'sni-only'
         WebACLId: !If
         - HasWAF

--- a/wordpress/wordpress-ha-aurora.yaml
+++ b/wordpress/wordpress-ha-aurora.yaml
@@ -1384,7 +1384,7 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref CloudFrontAcmCertificate
           SslSupportMethod: 'sni-only'
-          MinimumProtocolVersion: 'TLSv1.2_2019'
+          MinimumProtocolVersion: 'TLSv1.2_2025'
   BackupVault: # cannot be deleted with data
     Condition: HasEFSBackupRetentionPeriod
     Type: 'AWS::Backup::BackupVault'

--- a/wordpress/wordpress-ha.yaml
+++ b/wordpress/wordpress-ha.yaml
@@ -1507,7 +1507,7 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref CloudFrontAcmCertificate
           SslSupportMethod: 'sni-only'
-          MinimumProtocolVersion: 'TLSv1.2_2019'
+          MinimumProtocolVersion: 'TLSv1.2_2025'
   BackupVault: # cannot be deleted with data
     Condition: HasEFSBackupRetentionPeriod
     Type: 'AWS::Backup::BackupVault'


### PR DESCRIPTION
Upgrade the TLS protocol and ciphers to the latest standards (see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html)